### PR TITLE
Basic working version of rotate module

### DIFF
--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -23,7 +23,8 @@ logger = logging.getLogger(__name__)
 
 def main(args):
     """
-    Runs the end repair workflow
+    Runs the end repair workflow.
+
     :param args: arguments parsed by parse_cli()
     """
 
@@ -73,7 +74,8 @@ def main(args):
 
 def parse_assembly_info_file(assembly_info_filepath: str, info_type: str, return_type: str = 'circular'):
     """
-    List circular and linear contigs from a Flye (or custom format) assembly info file
+    List circular and linear contigs from a Flye (or custom format) assembly info file.
+
     :param assembly_info_filepath: path to assembly_info.txt output by Flye
     :param info_type: whether the info file is in 'flye' format or is a 'custom' format.
                       'flye' format refers to the 'assembly_info.txt' format output by Flye after a successful assembly.
@@ -145,7 +147,8 @@ def parse_assembly_info_file(assembly_info_filepath: str, info_type: str, return
 
 def subset_sequences(input_fasta_filepath: str, subset_sequence_ids: list):
     """
-    Given an input FastA file, subsets the file to the provided sequence IDs
+    Given an input FastA file, subsets the file to the provided sequence IDs.
+
     :param input_fasta_filepath: Path to the input FastA file
     :param subset_sequence_ids: list of the names of sequences to keep. If any names in the list are not in the
                                 input file, the function will not return anything for those names. The function will
@@ -178,7 +181,8 @@ def subset_sequences(input_fasta_filepath: str, subset_sequence_ids: list):
 
 def generate_bed_file(contig_seqrecord: SeqIO.SeqRecord, bed_filepath: str, length_threshold: int = 100000):
     """
-    Generates a BED file for a desired region around the ends of a contig
+    Generates a BED file for a desired region around the ends of a contig.
+
     :param contig_seqrecord: SeqRecord of the contig
     :param bed_filepath: desired output filepath for the BED file
     :param length_threshold: length (bp) around the contig end to target in the BED file.
@@ -214,7 +218,8 @@ def generate_bed_file(contig_seqrecord: SeqIO.SeqRecord, bed_filepath: str, leng
 def map_long_reads(contig_filepath: str, long_read_filepath: str, output_bam_filepath: str, log_filepath: str,
                    append_log: bool = True, threads: int = 1, threads_mem_mb: float = 1):
     """
-    Maps long reads (via minimap2) to contigs and sorts/indexes the resulting BAM file
+    Maps long reads (via minimap2) to contigs and sorts/indexes the resulting BAM file.
+
     :param contig_filepath: path to the FastA file containing the reference contigs
     :param long_read_filepath: path to the FastQ file containing long reads to map (compressed is OK)
     :param output_bam_filepath: path to the BAM file to be saved
@@ -251,7 +256,8 @@ def map_long_reads(contig_filepath: str, long_read_filepath: str, output_bam_fil
 def subset_reads_from_bam(bam_filepath: str, bed_filepath: str, subset_fastq_filepath: str, log_filepath: str,
                           append_log: bool = True, threads: int = 1):
     """
-    Subsets reads from a BAM file that were mapped to regions defined in a BED file; saves reads to a FastQ file
+    Subsets reads from a BAM file that were mapped to regions defined in a BED file; saves reads to a FastQ file.
+
     :param bam_filepath: path to a BAM file containing reads mapped to a reference; BAM needs to be sorted and indexed
     :param bed_filepath: path to a BED file containing the regions of reference contigs to subset reads for
     :param subset_fastq_filepath: path to the FastQ file to be saved (.fastq.gz extension saves as Gzipped FastQ)
@@ -279,7 +285,8 @@ def subset_reads_from_bam(bam_filepath: str, bed_filepath: str, subset_fastq_fil
 def run_flye(fastq_filepath: str, flye_outdir: str, flye_read_mode: str, flye_read_error: float, log_filepath: str,
              append_log: bool = True, threads: int = 1):
     """
-    Runs Flye to assemble the reads in the input FastQ file. This function allows Flye to fail without raising an error
+    Runs Flye to assemble the reads in the input FastQ file. This function allows Flye to fail without raising an error.
+
     :param fastq_filepath: path to a FastQ file containing the input reads (gzipped is OK)
     :param flye_outdir: directory to save Flye output to
     :param flye_read_mode: type of long reads, either 'nano-raw' or 'nano-hq'
@@ -322,7 +329,7 @@ def run_circlator_merge(circular_contig_filepath: str, patch_contig_filepath: st
                         circlator_reassemble_end: int, log_filepath: str, append_log: bool = True):
     """
     Runs the 'circlator merge' module to stitch a gap-spanning contig onto the ends of a circular contig to confirm and
-    repair the circularization of the contig
+    repair the circularization of the contig.
 
     :param circular_contig_filepath: path to a FastA file containing the original (non-stitched) circular contig
     :param patch_contig_filepath: path to a FastA file containing a linear contig that should span the 'ends' of the
@@ -353,7 +360,8 @@ def run_circlator_merge(circular_contig_filepath: str, patch_contig_filepath: st
 
 def check_circlator_success(circlator_logfile: str):
     """
-    Checks the circlator log file to see if contig stitching was successful
+    Checks the circlator log file to see if contig stitching was successful.
+
     :param circlator_logfile: path to the circlator log file
     :return: Boolean of whether the contigs were successfully stitched or not
     """
@@ -384,7 +392,8 @@ def check_circlator_success(circlator_logfile: str):
 
 def rotate_contig_to_midpoint(contig_fasta_filepath: str, output_filepath: str, append: bool = False):
     """
-    Rotates an input (circular) contig to its approximate midpoint
+    Rotates an input (circular) contig to its approximate midpoint.
+
     :param contig_fasta_filepath: path to a FastA file containing a single circular contig
     :param output_filepath: path where the FastA file containing the output rotated contig should be saved
     :param append: whether to append the output FastA onto an existing file (True) or overwrite (False)
@@ -427,7 +436,7 @@ def rotate_contig_to_midpoint(contig_fasta_filepath: str, output_filepath: str, 
 def link_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: str, length_outdir: str, length_threshold: int,
                      cli_tool_settings_dict: dict, verbose_logfile: str, threads: int = 1):
     """
-    Attempt to stitch the ends of an input circular contig via assembling reads mapped within x bp of the contig ends
+    Attempt to stitch the ends of an input circular contig via assembling reads mapped within x bp of the contig ends.
 
     :param contig_record: SeqRecord of the circular contig
     :param bam_filepath: path to a BAM file with mapping information of long reads to the contig (it is OK if this file
@@ -493,7 +502,7 @@ def iterate_linking_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: st
                                 length_thresholds: list, cli_tool_settings_dict: dict,  verbose_logfile: str,
                                 threads: int = 1):
     """
-    Iterate link_contig_ends to try to stitch the ends of a circular contig using multiple length thresholds
+    Iterate link_contig_ends to try to stitch the ends of a circular contig using multiple length thresholds.
 
     :param contig_record: SeqRecord of the circular contig
     :param bam_filepath: path to a BAM file with mapping information of long reads to the contig (it is OK if this file
@@ -676,7 +685,7 @@ def run_end_repair(long_read_filepath: str, assembly_fasta_filepath: str, assemb
                    assembly_info_type: str, output_dir: str, length_thresholds: list, keep_failed_contigs: bool,
                    cli_tool_settings_dict: dict, threads: int, threads_mem_mb: int):
     """
-    Runs the end repair workflow
+    Runs the end repair workflow.
 
     :param long_read_filepath: path to the QC-passing Nanopore reads, FastQ format; gzipped is OK
     :param assembly_fasta_filepath: path to the assembled contigs output by Flye, FastA format
@@ -806,6 +815,7 @@ def run_end_repair(long_read_filepath: str, assembly_fasta_filepath: str, assemb
 def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
     """
     Parses the CLI arguments and adds them as a subparser to an existing parser.
+    
     :param subparsers: A special subparser action object created from an existing parser by the add_subparsers() method.
                        For example, parser = argparse.ArgumentParser(); subparsers = parser.add_subparsers().
     :param parent_parser: An optional ArgParse object with additional arguments (e.g., shared across all modules) to
@@ -816,7 +826,7 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
 
     description = 'Repairs ends of circular contigs from Flye.'
 
-    # Initialize within the provided parent parser
+    # Initialize within the provided subparser
     subparser = subparsers.add_parser('repair', help=description, parents=[parent_parser] if parent_parser else [])
 
     # Add attribute to tell main() what sub-command was called.

--- a/rotary_utils/rotary_utils.py
+++ b/rotary_utils/rotary_utils.py
@@ -9,7 +9,7 @@ import os
 import logging
 import argparse
 
-from rotary_utils.utils import check_log_file, set_up_output_directory
+from rotary_utils.utils import check_output_file, set_up_output_directory
 from rotary_utils.rotate import main as rotate_main
 from rotary_utils.rotate import subparse_cli as subparse_rotate_cli
 from rotary_utils.repair import main as repair_main
@@ -44,7 +44,7 @@ def main():
 
     # File logger setup
     if (hasattr(args, 'logfile')) and (args.logfile is not None):
-        check_log_file(log_filepath=args.logfile, overwrite=args.overwrite)
+        check_output_file(output_filepath=args.logfile, overwrite=args.overwrite)
 
         # Note: The logging level set here is the minimum level that the logger can write to. The actual level is
         #       defined for the root logger above in the args.verbose conditional.

--- a/rotary_utils/rotary_utils.py
+++ b/rotary_utils/rotary_utils.py
@@ -10,6 +10,8 @@ import logging
 import argparse
 
 from rotary_utils.utils import check_log_file, set_up_output_directory
+from rotary_utils.rotate import main as rotate_main
+from rotary_utils.rotate import subparse_cli as subparse_rotate_cli
 from rotary_utils.repair import main as repair_main
 from rotary_utils.repair import subparse_cli as subparse_repair_cli
 
@@ -63,6 +65,8 @@ def main():
         logger.addHandler(output_dir_file_handler)
 
     # Select the sub-command to run.
+    if hasattr(args, 'rotate'):
+        rotate_main(args)
     if hasattr(args, 'repair'):
         repair_main(args)
     else:
@@ -91,6 +95,7 @@ def parse_cli():
                               help='Enable verbose logging')
 
     # Declare sub-commands
+    subparse_rotate_cli(subparsers, parent_parser)
     subparse_repair_cli(subparsers, parent_parser)
 
     return parser

--- a/rotary_utils/rotary_utils.py
+++ b/rotary_utils/rotary_utils.py
@@ -67,7 +67,7 @@ def main():
     # Select the sub-command to run.
     if hasattr(args, 'rotate'):
         rotate_main(args)
-    if hasattr(args, 'repair'):
+    elif hasattr(args, 'repair'):
         repair_main(args)
     else:
         parser.print_help()

--- a/rotary_utils/rotate.py
+++ b/rotary_utils/rotate.py
@@ -226,49 +226,41 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
     rotate_settings = subparser.add_argument_group('Rotate options')
     workflow_settings = subparser.add_argument_group('Workflow options')
 
-    required_settings.add_argument('-i', '--input_fasta', required=True, type=str,
+    required_settings.add_argument('-i', '--input_fasta', metavar='PATH', required=True, type=str,
                                    help='Input contig fasta file')
-    required_settings.add_argument('-o', '--output_fasta', required=True, type=str,
+    required_settings.add_argument('-o', '--output_fasta', metavar='PATH', required=True, type=str,
                                    help='Output contig fasta file. (Note that all input contigs will always be '
                                         'written to output. If you select no rotate options, the input contigs will '
                                         'be output with no sequence changes.)')
 
     rotate_settings.add_argument('-m', '--midpoint', required=False, action='store_true',
                                  help='Rotate all contigs to their midpoint (overrides -p, -P, -t, and -T)')
-    rotate_settings.add_argument('-p', '--rotate_position', required=False, type=int,
+    rotate_settings.add_argument('-p', '--rotate_position', metavar='INT', required=False, type=int,
                                  help='Base pair position to rotate contigs to (to specify a unique rotate '
                                       'position for each contig, see -t). Incompatible with -P.')
-    rotate_settings.add_argument('-t', '--rotate_position_table', required=False, type=str,
+    rotate_settings.add_argument('-t', '--rotate_position_table', metavar='PATH', required=False, type=str,
                                  help='Path to a tab-separated file that contains the exact rotate position of '
-                                      'each contig. Columns (with headers) should be "contig_id" and "rotate_position". '
-                                      'Overrides -p and -P. Only contigs specified in the table will be rotated, although '
-                                      'all contigs in the input file will be written to the output file. Incompatible with '
-                                      '-T.')
-    rotate_settings.add_argument('-P', '--rotate_proportion', required=False, type=float,
-                                 help='Fractional position to rotate contigs to (e.g., 0.3 to rotate 30% of total length). '
-                                      'To specify a unique fractional position to rotate for each contig, see -T). '
-                                      'Incompatible with -p.')
-    rotate_settings.add_argument('-T', '--rotate_proportion_table', required=False, type=str,
-                                 help='Path to a tab-separated file that contains the exact fractional positions to rotate '
-                                      'each contig to. Columns (with headers) should be "contig_id" and "rotate_proportion". '
-                                      'Overrides -p and -P. Only contigs specified in the table will be rotated, although '
-                                      'all contigs in the input file will be written to the output file. Incompatible '
-                                      'with -t.')
-    rotate_settings.add_argument('-c', '--contig_names', required=False, type=str,
+                                      'each contig. Columns (with headers) should be "contig_id" and '
+                                      '"rotate_position". Overrides -p and -P. Only contigs specified in the table '
+                                      'will be rotated, although all contigs in the input file will be written to the '
+                                      'output file. Incompatible with -T.')
+    rotate_settings.add_argument('-P', '--rotate_proportion', metavar='FRACTION', required=False, type=float,
+                                 help='Fractional position to rotate contigs to (e.g., 0.3 to rotate 30% of total '
+                                      'length). To specify a unique fractional position to rotate for each contig, see '
+                                      '-T). Incompatible with -p.')
+    rotate_settings.add_argument('-T', '--rotate_proportion_table', metavar='PATH', required=False, type=str,
+                                 help='Path to a tab-separated file that contains the exact fractional positions to '
+                                      'rotate each contig to. Columns (with headers) should be "contig_id" and '
+                                      '"rotate_proportion". Overrides -p and -P. Only contigs specified in the table '
+                                      'will be rotated, although all contigs in the input file will be written to the '
+                                      'output file. Incompatible with -t.')
+    rotate_settings.add_argument('-c', '--contig_names', metavar='LIST', required=False, type=str,
                                  help='Contigs to be rotated (comma-separated list of IDs). '
                                       'Rotate operations will only be applied to these contigs, '
                                       'although all contigs in the input file will be written to output. '
                                       'If used with -t or -T, the contigs listed in the table will be further subset '
                                       'to those that are also in the provided list of contig names.')
-    rotate_settings.add_argument('-r', '--output_report', required=False, type=str,
+    rotate_settings.add_argument('-r', '--output_report', metavar='PATH', required=False, type=str,
                                  help='Path to write an optional report file that shows how contigs were rotated')
-    rotate_settings.add_argument('-b', '--base_start_position', required=False, default=1, type=int,
-                                 choices=[0, 1],
-                                 help='Whether the first base position on a contig is considered as 1 (default) or 0.')
-
-    workflow_settings.add_argument('-t', '--threads', required=False, default=1, type=int,
-                                   help='Number of processors threads to use (default: 1)')
-    workflow_settings.add_argument('-v', '--verbose', required=False, action='store_true',
-                                   help='Enable verbose logging to screen')
 
     return subparser

--- a/rotary_utils/rotate.py
+++ b/rotary_utils/rotate.py
@@ -196,7 +196,8 @@ def rotate_sequence_to_position(sequence_record: SeqIO.SeqRecord, rotate_positio
     Rotates an input (circular) sequence to a specified position.
 
     :param sequence_record: BioPython SeqRecord object containing the sequence to rotate
-    :param rotate_position: new start position for the sequence after rotation (if 0, sequence is not rotated)
+    :param rotate_position: new start position for the sequence after rotation (if 0, sequence is not rotated). This can
+                            also be thought of as the number of bases to rotate counter-clockwise.
     :param strip_description: boolean of whether to trim off the read description in the output sequences
     :param quiet: run without logger debug outputs (for compatibility with rotate_sequence_to_fraction)
     :return: BioPython SeqRecord object of the rotated FastA file
@@ -239,7 +240,7 @@ def rotate_sequence_to_fraction(sequence_record: SeqIO.SeqRecord, rotate_fractio
 
     :param sequence_record: BioPython SeqRecord object containing the sequence to rotate
     :param rotate_fraction: fraction of the sequence length to rotate the sequence to (rounded down to nearest bp). Set
-                            to 0.5 to rotate to midpoint.
+                            to 0.5 to rotate to midpoint. Rotates counter-clockwise.
     :param strip_description: boolean of whether to trim off the read description in the output sequences
     :return: BioPython SeqRecord object of the rotated FastA file
     """
@@ -272,9 +273,10 @@ def rotate_sequences_wf(fasta_filepath: str, output_filepath: str, rotate_type: 
     :param rotate_type: whether the rotation is a 'position' based or a 'fraction' based rotation
     :param rotate_values: dict of sequence names (keys) and the desired rotation position or fraction for each sequence
                           (values). If rotate_type if 'position', expects the values to be the new start position for
-                          each sequence after rotation. If rotate_type if 'fraction', expects the values to be the
-                          fraction of total sequence length to rotate. If the value is set to 0 for a sequence, then
-                          that sequence is not rotated.
+                          each sequence after rotation (i.e., the number of bases to rotate counter-clockwise). If
+                          rotate_type if 'fraction', expects the values to be the fraction of total sequence length to
+                          rotate (counter-clockwise). If the value is set to 0 for a sequence, then that sequence is not
+                          rotated.
     :param rotate_value_single: a single value (position or fraction, depending on rotate_type) to rotate all sequences
                                 to. This is useful if you want to rotate all sequences to their midpoint, for example,
                                 via rotate_value_single=0.5 and rotate_type='fraction'. As a warning, if doing
@@ -394,25 +396,26 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
     rotate_settings.add_argument('-m', '--midpoint', required=False, action='store_true',
                                  help='Rotate all sequences to their midpoint. (Incompatible with -p, -P, -t, and -T.)')
     rotate_settings.add_argument('-p', '--rotate_position', metavar='INT', required=False, type=int,
-                                 help='Base pair position to rotate all sequences to (to specify a unique rotate '
-                                      'position for each sequence, see -t). Incompatible with -m, -P, -t, and -T.')
+                                 help='Base pair position to rotate all sequences to (i.e., number of bases to rotate '
+                                      'counter-clockwise). To specify a unique rotate position for each sequence, see '
+                                      '-t). Incompatible with -m, -P, -t, and -T.')
     rotate_settings.add_argument('-P', '--rotate_fraction', metavar='INT', required=False, type=int,
-                                 help='Fractional position to rotate all sequences to (for example, 0.3 means to '
-                                      'rotate all contigs to 30 percent of their total length). To specificy a unique '
-                                      'fractional position for each sequence, see -T). Incompatible with -m, -p, -t, '
-                                      'and -T.')
+                                 help='Fractional position to rotate all sequences to, counter-clockwise. For example, '
+                                      '0.3 means to rotate all contigs counter-clockwise to 30 percent of their total '
+                                      'length). To specify a unique fractional position for each sequence, see -T). '
+                                      'Incompatible with -m, -p, -t, and -T.')
     rotate_settings.add_argument('-t', '--rotate_position_table', metavar='PATH', required=False, type=str,
                                  help='Path to a tab-separated file that contains the exact rotate position of '
-                                      'each sequence. Columns (with headers) should be "sequence_id" and '
-                                      '"rotate_position". Only sequences specified in the table will be rotated, '
-                                      'although all sequences in the input file will be written to the output file. '
-                                      'Incompatible with -m, -p, -P, and -T.')
+                                      'each sequence (i.e., bases to rotate counter-clockwise). Columns (with headers) '
+                                      'should be "sequence_id" and "rotate_position". Only sequences specified in the '
+                                      'table will be rotated, although all sequences in the input file will be written '
+                                      'to the output file. Incompatible with -m, -p, -P, and -T.')
     rotate_settings.add_argument('-T', '--rotate_fraction_table', metavar='PATH', required=False, type=str,
                                  help='Path to a tab-separated file that contains the exact fractional positions to '
-                                      'rotate each sequence to. Columns (with headers) should be "sequence_id" and '
-                                      '"rotate_fraction". Only sequences specified in the table will be rotated, '
-                                      'although all sequences in the input file will be written to the output file. '
-                                      'Incompatible with -m, -p, -P, and -t.')
+                                      'rotate each sequence to, in the counter-clockwise direction. Columns (with '
+                                      'headers) should be "sequence_id" and "rotate_fraction". Only sequences '
+                                      'specified in the table will be rotated, although all sequences in the input '
+                                      'file will be written to the output file. Incompatible with -m, -p, -P, and -t.')
     rotate_settings.add_argument('-n', '--sequence_names', metavar='LIST', required=False, type=str, default=None,
                                  help='Sequences to be rotated (comma-separated list of IDs). Rotate operations will '
                                       'only be applied to these sequences, although all sequences in the input file '

--- a/rotary_utils/rotate.py
+++ b/rotary_utils/rotate.py
@@ -10,13 +10,13 @@ import sys
 import math
 
 from Bio import SeqIO
+import pandas as pd
 
 from rotary_utils.utils import set_write_mode, load_fasta_sequences
 
 logger = logging.getLogger(__name__)
 
 
-# TODO: this is just a placeholder function for now to show some of the features I'd like to add to the CLI later on.
 def main(args):
     """
     Starts the rotate utility.
@@ -24,31 +24,139 @@ def main(args):
     :param args: args parsed by parse_cli()
     """
 
-    # Parse some command line inputs further
-    # TODO: improve error handling if a string is provided instead of a real length
-    # TODO: confirm what the default value of args.contig_names will be - might need to specify
-    if args.contig_names is not None:
-        contig_names = [int(x) for x in args.contig_names.split(',')]
-
     # Startup messages
     logger.info('Running ' + os.path.basename(sys.argv[0]))
     logger.debug('### SETTINGS ###')
     logger.debug(f'Input FastA: {args.input_fasta}')
     logger.debug(f'Output FastA: {args.output_fasta}')
-    # TODO: finish the rest of the startup messages
-
-    logger.debug(f'Threads: {args.threads}')
+    logger.debug(f'Midpoint rotation: {args.midpoint}')
+    logger.debug(f'Constant rotate position: {args.rotate_position}')
+    logger.debug(f'Constant rotate proportion: {args.rotate_proportion}')
+    logger.debug(f'Rotate position table: {args.rotate_position_table}')
+    logger.debug(f'Rotate proportion table: {args.rotate_proportion_table}')
+    logger.debug(f'Sequence names to rotate: {args.sequence_names}')
+    logger.debug(f'Rotation report: {args.output_report}')
+    logger.debug(f'Strip FastA header descriptions: {args.strip_descriptions}')
     logger.debug(f'Verbose logging: {args.verbose}')
     logger.debug('################')
 
-    # TODO: add rotate code
+    # Check that the user has provided OK instructions
+    check_rotate_args(args)
+
+    # TODO: improve error handling if a string is provided instead of a real length
+    if args.sequence_names is not None:
+        sequence_names = [int(x) for x in args.sequence_names.split(',')]
+    else:
+        sequence_names = None
+
+    # Perform the rotate operation based on which of the rotate arguments was specified by the user
+    if args.midpoint is True:
+        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='fraction',
+                                     rotate_value_single=0.5, sequence_names=sequence_names,
+                                     strip_descriptions=args.strip_descriptions)
+
+    elif args.rotate_position is not None:
+        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='position',
+                                     rotate_value_single=args.rotate_position, sequence_names=sequence_names,
+                                     strip_descriptions=args.strip_descriptions)
+
+    elif args.rotate_proportion is not None:
+        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='fraction',
+                                     rotate_value_single=args.rotate_proportion, sequence_names=sequence_names,
+                                     strip_descriptions=args.strip_descriptions)
+
+    elif args.rotate_position_table is not None:
+        rotate_values_dict = parse_rotate_value_table(args.rotate_position_table, rotate_type='position')
+
+        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='position',
+                                     rotate_values=rotate_values_dict, sequence_names=sequence_names,
+                                     strip_descriptions=args.strip_descriptions)
+
+    elif args.rotate_proportion_table is not None:
+        rotate_values_dict = parse_rotate_value_table(args.rotate_position_table, rotate_type='fraction')
+
+        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='fraction',
+                                     rotate_values=rotate_values_dict, sequence_names=sequence_names,
+                                     strip_descriptions=args.strip_descriptions)
+
+    else:
+        raise RuntimeError('Could not find any rotate commands to execute.')
+
+    # Save the rotation report if desired
+    if args.output_report is not None:
+        # TODO: error if report file exists
+        report.to_csv(args.output_report, sep='\t', index=False)
 
     logger.info(os.path.basename(sys.argv[0]) + ': done.')
 
 
+def check_rotate_args(args):
+    """
+    Checks that the arguments supplied to the rotate module are non-conflicting. Errors if a conflict is found.
+
+    :param args: Arguments parsed by subparse_cli()
+    """
+
+    """
+    As described in the README, only one of the following arguments is allowed to be set for a run:
+    
+    args.midpoint
+    args.rotate_position
+    args.rotate_proportion
+    args.rotate_position_table
+    args.rotate_proportion_table
+    """
+
+    rotate_value_arguments = [args.midpoint, args.rotate_position, args.rotate_proportion, args.rotate_position_table,
+                              args.rotate_proportion_table]
+
+    defined_arguments = 0
+    for argument in rotate_value_arguments:
+        if argument is not None:
+            defined_arguments = defined_arguments + 1
+
+    if defined_arguments > 1:
+        raise RuntimeError('More than one of -m, -p, -P, -t, and -T were specified in the command line, but only one '
+                           'of these can be set for a rotate run.')
+    elif defined_arguments == 0:
+        raise RuntimeError('None of -m, -p, -P, -t, and -T were specified in the command line, but you must select one '
+                           'of these to perform a rotate run.')
+    else:
+        raise RuntimeError('Ran into an issue processing the -m, -p, -P, -t, and -T arguments in the CLI.')
+
+
+def parse_rotate_value_table(rotate_table_filepath: str, rotate_type: str):
+    """
+    Parses a tab-separated table as defined in the CLI containing rotation information.
+
+    :param rotate_table_filepath: path to the tab-separated table with sequence rotation info
+    :param rotate_type: either 'position' or 'fraction'. Runs a check to make sure column names match the specified
+                        rotation type.
+    :return: dictionary of sequence names (keys) and rotation values (values)
+    """
+
+    if rotate_type == 'position':
+        expected_column_names = ['sequence_id', 'rotate_position']
+    elif rotate_type == 'fraction':
+        expected_column_names = ['sequence_id', 'rotate_proportion']
+    else:
+        raise ValueError(f'Expected "position" or "fraction", but got "{rotate_type}".')
+
+    rotate_table = pd.read_csv(rotate_table_filepath, sep='\t')
+
+    if expected_column_names not in rotate_table.columns:
+        raise RuntimeError(f'Because rotate_type was set as "{rotate_type}", expected the column names '
+                           f'"{",".join(expected_column_names)}", but could not find these in the loaded columns.'
+                           f'Instead, found "{",".join(rotate_table.columns)}"')
+
+    rotate_values_dict = dict(zip(rotate_table[expected_column_names[0]], rotate_table[expected_column_names[1]]))
+
+    return rotate_values_dict
+
+
 def parse_gene_positions():
     """
-    Parses the positions of genes along a contig.
+    Parses the positions of genes along a sequence.
 
     :return: table of gene positions
     """
@@ -73,7 +181,7 @@ def rotate_sequence_to_position(sequence_record: SeqIO.SeqRecord, rotate_positio
     Rotates an input (circular) sequence to a specified position.
 
     :param sequence_record: BioPython SeqRecord object containing the sequence to rotate
-    :param rotate_position: new start position for the contig after rotation (if 0, contig is not rotated)
+    :param rotate_position: new start position for the sequence after rotation (if 0, sequence is not rotated)
     :param strip_description: boolean of whether to trim off the read description in the output sequences
     :return: BioPython SeqRecord object of the rotated FastA file
     """
@@ -86,19 +194,19 @@ def rotate_sequence_to_position(sequence_record: SeqIO.SeqRecord, rotate_positio
 
     elif rotate_position == sequence_length:
         logger.warning(f'Desired rotate position ({rotate_position}) is equal to the sequence length '
-                       f'({sequence_length} bp), so the contig will effectively not be rotated.')
+                       f'({sequence_length} bp), so the sequence will effectively not be rotated.')
 
     elif rotate_position < 0:
         logger.debug(f'Desired rotate position ({rotate_position}) is less than 0.')
         raise RuntimeError
 
     logger.debug(f'Rotating sequence to start at position: {rotate_position}')
-    contig_sequence_rotated_front = sequence_record.seq[rotate_position:sequence_length]
-    contig_sequence_rotated_back = sequence_record.seq[0:rotate_position]
-    contig_sequence_rotated = contig_sequence_rotated_front + contig_sequence_rotated_back
+    sequence_rotated_front = sequence_record.seq[rotate_position:sequence_length]
+    sequence_rotated_back = sequence_record.seq[0:rotate_position]
+    sequence_rotated = sequence_rotated_front + sequence_rotated_back
 
     # Update SeqRecord
-    sequence_record.seq = contig_sequence_rotated
+    sequence_record.seq = sequence_rotated
 
     if strip_description:
         sequence_record.description = sequence_record.name
@@ -112,7 +220,8 @@ def rotate_sequence_to_fraction(sequence_record: SeqIO.SeqRecord, rotate_fractio
     Rotates an input (circular) sequence to a specified fraction of the total length.
 
     :param sequence_record: BioPython SeqRecord object containing the sequence to rotate
-    :param rotate_fraction: fraction of the contig length to rotate the contig to (rounded down to nearest bp)
+    :param rotate_fraction: fraction of the sequence length to rotate the sequence to (rounded down to nearest bp). Set
+                            to 0.5 to rotate to midpoint.
     :param strip_description: boolean of whether to trim off the read description in the output sequences
     :return: BioPython SeqRecord object of the rotated FastA file
     """
@@ -132,74 +241,95 @@ def rotate_sequence_to_fraction(sequence_record: SeqIO.SeqRecord, rotate_fractio
     return sequence_record
 
 
-def rotate_sequence_to_midpoint(sequence_record: SeqIO.SeqRecord, strip_description: bool = True):
-    """
-    Rotates an input (circular) sequence to the approximate midpoint.
-
-    :param sequence_record: BioPython SeqRecord object containing the sequence to rotate
-    :param strip_description: boolean of whether to trim off the read description in the output sequences
-    :return: BioPython SeqRecord object of the rotated FastA file
-    """
-
-    sequence_record = rotate_sequence_to_fraction(sequence_record, rotate_fraction=0.5,
-                                                  strip_description=strip_description)
-    return sequence_record
-
-
-def rotate_sequences_wf(fasta_filepath: str, output_filepath: str, rotate_type: str, rotate_values: dict,
+def rotate_sequences_wf(fasta_filepath: str, output_filepath: str, rotate_type: str, rotate_values: dict = None,
+                        rotate_value_single: float = None, sequence_names: list = None,
                         append: bool = False, strip_descriptions: bool = True):
     """
-    Rotates all (circular) sequences in an input FastA file to a specified position.
+    Rotates all (circular) sequences in an input FastA file to specified positions or fractions.
 
     :param fasta_filepath: Path to the FastA file (unzipped) to load
-    :param output_filepath: path where the FastA file containing the output rotated contig should be saved
-    :param rotate_type: whether the rotation is a 'position' based or a 'fraction' based rotation.
-    :param rotate_values: dict of contig names (keys) and the desired rotation position or fraction for each contig
+    :param output_filepath: path where the FastA file containing the output rotated sequence should be saved
+    :param rotate_type: whether the rotation is a 'position' based or a 'fraction' based rotation
+    :param rotate_values: dict of sequence names (keys) and the desired rotation position or fraction for each sequence
                           (values). If rotate_type if 'position', expects the values to be the new start position for
-                          each contigs after rotation. If rotate_type if 'fraction', expects the values to be the
-                          fraction (or proportion) of total contig length to rotate. (If 0, the contig is not rotated.)
+                          each sequence after rotation. If rotate_type if 'fraction', expects the values to be the
+                          fraction (or proportion) of total sequence length to rotate. If the value is set to 0 for a
+                          sequence, then that sequence is not rotated.
+    :param rotate_value_single: a single value (position or fraction, depending on rotate_type) to rotate all sequences
+                                to. This is useful if you want to rotate all sequences to their midpoint, for example,
+                                via rotate_value_single=0.5 and rotate_type='fraction'. As a warning, if doing
+                                positional rotation, the largest you can rotate to is the length of the shortest
+                                sequence. This param cannot be set at the same time as rotate_values.
+    :param sequence_names: list of sequence header IDs. Rotate operations will only be performed on these names.
     :param append: whether to append the output FastA onto an existing file (True) or overwrite (False)
     :param strip_descriptions: boolean of whether to trim off the read description in the output sequences
-    :return: writes file to disk
+    :return: tabular report of rotation stats for each sequence
     """
 
+    subset_rotation = True if sequence_names is not None else False
+
+    # Parse what kind of rotation values were supplied
+    if (rotate_values is not None) and (rotate_value_single is not None):
+        raise RuntimeError('Cannot set both rotate_values and rotate_value_single.')
+    elif (rotate_values is None) and (rotate_value_single is None):
+        raise RuntimeError('Must set one of rotate_values and rotate_value_single.')
+
+    sequence_ids = []
+    sequence_lengths = []
+    final_rotate_values = []
+
+    # Rotate each sequence by the specified amount
     write_mode = set_write_mode(append)
     with open(output_filepath, write_mode) as output_handle:
         for record in load_fasta_sequences(fasta_filepath):
 
-            if rotate_type == 'position':
-                record_rotated = rotate_sequence_to_position(record, rotate_position=rotate_values[record.name],
-                                                             strip_description=strip_descriptions)
-            elif rotate_type == 'fraction':
-                record_rotated = rotate_sequence_to_fraction(record, rotate_fraction=rotate_values[record.name],
-                                                             strip_description=strip_descriptions)
+            # If rotating specific sequences is turned off, then add the specified sequence ID to the rotation list so
+            # that it passes the sequence name check
+            if subset_rotation is False:
+                sequence_names = [record.name]
+
+            if record.name in sequence_names:
+
+                # Get the rotation value for the sequence record
+                if rotate_values is not None:
+                    try:
+                        rotate_value = rotate_values[record.name]
+                    except KeyError:
+                        logger.debug(f'Sequence name {record.name} was not supplied in rotate_values. Will not rotate.')
+                        rotate_value = 0
+
+                elif rotate_value_single is not None:
+                    rotate_value = rotate_value_single
+
+                else:
+                    raise RuntimeError('Could not find rotate_values or rotate_value_single.')
+
+                # Rotate the sequence
+                if rotate_type == 'position':
+                    record_rotated = rotate_sequence_to_position(record, rotate_position=rotate_value,
+                                                                 strip_description=strip_descriptions)
+                elif rotate_type == 'fraction':
+                    record_rotated = rotate_sequence_to_fraction(record, rotate_fraction=rotate_value,
+                                                                 strip_description=strip_descriptions)
+                else:
+                    raise ValueError(f'Expected "position" or "fraction", but not {rotate_type}')
+
             else:
-                raise ValueError(f'Expected "position" or "fraction", but hot {rotate_type}')
+                # Just pass the record through without rotation
+                record_rotated = rotate_sequence_to_position(record, rotate_position=0,
+                                                             strip_description=strip_descriptions)
+
+            # Get values for output report
+            sequence_ids.append(record.name)
+            sequence_lengths.append(len(record.seq))
+            final_rotate_values.append(rotate_value)
 
             SeqIO.write(record_rotated, output_handle, 'fasta')
 
+    output_report = pd.DataFrame({'sequence_id': sequence_ids, 'sequence_length_bp': sequence_lengths,
+                                  'rotate_type': rotate_type, 'rotate_value': final_rotate_values})
 
-def rotate_all_sequences_to_same_fraction_wf(fasta_filepath: str, output_filepath: str, rotate_fraction: float,
-                                             append: bool = False, strip_descriptions: bool = True):
-    """
-    Rotates all sequences in an input FastA file to a desired fraction, assuming they are circular.
-
-    :param fasta_filepath: Path to the FastA file (unzipped) to load. Assumes all entries are circular.
-    :param output_filepath: path where the FastA file containing the output rotated contig should be saved
-    :param rotate_fraction: the fraction of the sequence length to rotate each sequence to. Set to 0.5 to rotate to
-                            the midpoint of each sequence.
-    :param append: whether to append the output FastA onto an existing file (True) or overwrite (False)
-    :param strip_descriptions: boolean of whether to trim off the read description in the output sequences
-    :return: writes file to disk
-    """
-
-    write_mode = set_write_mode(append)
-    with open(output_filepath, write_mode) as output_handle:
-        for record in load_fasta_sequences(fasta_filepath):
-
-            record_rotated = rotate_sequence_to_fraction(record, rotate_fraction=rotate_fraction,
-                                                         strip_description=strip_descriptions)
-            SeqIO.write(record_rotated, output_handle, 'fasta')
+    return output_report
 
 
 def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
@@ -214,7 +344,7 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
     :return: An ArgumentParser object created by subparsers.add_parser()
     """
 
-    description = """Rotates circular contigs."""
+    description = """Rotates circular sequence."""
 
     # Initialize within the provided subparser
     subparser = subparsers.add_parser('rotate', help=description, parents=[parent_parser] if parent_parser else [])
@@ -227,40 +357,45 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
     workflow_settings = subparser.add_argument_group('Workflow options')
 
     required_settings.add_argument('-i', '--input_fasta', metavar='PATH', required=True, type=str,
-                                   help='Input contig fasta file')
+                                   help='Input fasta file')
     required_settings.add_argument('-o', '--output_fasta', metavar='PATH', required=True, type=str,
-                                   help='Output contig fasta file. (Note that all input contigs will always be '
-                                        'written to output. If you select no rotate options, the input contigs will '
-                                        'be output with no sequence changes.)')
+                                   help='Output fasta file. Note that all input sequences will always be '
+                                        'written to output, even if only a subset of sequences are selected for '
+                                        'rotate operations.')
 
     rotate_settings.add_argument('-m', '--midpoint', required=False, action='store_true',
-                                 help='Rotate all contigs to their midpoint (overrides -p, -P, -t, and -T)')
+                                 help='Rotate all sequences to their midpoint. (Incompatible with -p, -P, -t, and -T.)')
     rotate_settings.add_argument('-p', '--rotate_position', metavar='INT', required=False, type=int,
-                                 help='Base pair position to rotate contigs to (to specify a unique rotate '
-                                      'position for each contig, see -t). Incompatible with -P.')
+                                 help='Base pair position to rotate all sequences to (to specify a unique rotate '
+                                      'position for each sequence, see -t). Incompatible with -m, -P, -t, and -T.')
+    rotate_settings.add_argument('-P', '--rotate_proportion', metavar='FRACTION', required=False, type=float,
+                                 help='Fractional position to rotate sequences to (e.g., 0.3 to rotate 30% of total '
+                                      'length). To specify a unique fractional position to rotate for each sequence, '
+                                      'see -T). Incompatible with -m, -p, -t, and -T.')
     rotate_settings.add_argument('-t', '--rotate_position_table', metavar='PATH', required=False, type=str,
                                  help='Path to a tab-separated file that contains the exact rotate position of '
-                                      'each contig. Columns (with headers) should be "contig_id" and '
-                                      '"rotate_position". Overrides -p and -P. Only contigs specified in the table '
-                                      'will be rotated, although all contigs in the input file will be written to the '
-                                      'output file. Incompatible with -T.')
-    rotate_settings.add_argument('-P', '--rotate_proportion', metavar='FRACTION', required=False, type=float,
-                                 help='Fractional position to rotate contigs to (e.g., 0.3 to rotate 30% of total '
-                                      'length). To specify a unique fractional position to rotate for each contig, see '
-                                      '-T). Incompatible with -p.')
+                                      'each sequence. Columns (with headers) should be "sequence_id" and '
+                                      '"rotate_position". Only sequences specified in the table will be rotated, '
+                                      'although all sequences in the input file will be written to the output file. '
+                                      'Incompatible with -m, -p, -P, and -T.')
     rotate_settings.add_argument('-T', '--rotate_proportion_table', metavar='PATH', required=False, type=str,
                                  help='Path to a tab-separated file that contains the exact fractional positions to '
-                                      'rotate each contig to. Columns (with headers) should be "contig_id" and '
-                                      '"rotate_proportion". Overrides -p and -P. Only contigs specified in the table '
-                                      'will be rotated, although all contigs in the input file will be written to the '
-                                      'output file. Incompatible with -t.')
-    rotate_settings.add_argument('-c', '--contig_names', metavar='LIST', required=False, type=str,
-                                 help='Contigs to be rotated (comma-separated list of IDs). '
-                                      'Rotate operations will only be applied to these contigs, '
-                                      'although all contigs in the input file will be written to output. '
-                                      'If used with -t or -T, the contigs listed in the table will be further subset '
-                                      'to those that are also in the provided list of contig names.')
+                                      'rotate each sequence to. Columns (with headers) should be "sequence_id" and '
+                                      '"rotate_proportion". Only sequences specified in the table will be rotated, '
+                                      'although all sequences in the input file will be written to the output file. '
+                                      'Incompatible with -m, -p, -P, and -t.')
+    rotate_settings.add_argument('-n', '--sequence_names', metavar='LIST', required=False, type=str, default=None,
+                                 help='Sequences to be rotated (comma-separated list of IDs). Rotate operations will '
+                                      'only be applied to these sequences, although all sequences in the input file '
+                                      'will be written to output. If used with -t or -T, the sequences listed in the '
+                                      'table will be further subset to those that are also in the provided list of '
+                                      'sequence names.')
     rotate_settings.add_argument('-r', '--output_report', metavar='PATH', required=False, type=str,
-                                 help='Path to write an optional report file that shows how contigs were rotated')
+                                 help='Path to write an optional tab-separated report file that shows how sequences '
+                                      'were rotated.')
+
+    workflow_settings.add_argument('-s', '--strip_descriptions', required=False, action='store_true',
+                                   help='Strip descriptions off FastA headers (i.e., any text after the first '
+                                        'whitespace in each header)')
 
     return subparser

--- a/rotary_utils/rotate.py
+++ b/rotary_utils/rotate.py
@@ -44,10 +44,10 @@ def main(args):
     # Check that the user has provided OK instructions
     check_rotate_args(args)
 
-    # TODO: improve error handling if a string is provided instead of a real length
+    # TODO: improve error handling if a bad comma-separated list is provided
     if args.sequence_names is not None:
-        sequence_names = [int(x) for x in args.sequence_names.split(',')]
-        logger.debug(f'User provided a list of {len(args.sequence_names)} sequence IDs to search for rotation.')
+        sequence_names = args.sequence_names.split(',')
+        logger.debug(f'User provided a list of {len(sequence_names)} sequence IDs to search for rotation.')
     else:
         sequence_names = None
 
@@ -340,7 +340,8 @@ def rotate_sequences_wf(fasta_filepath: str, output_filepath: str, rotate_type: 
 
             else:
                 # Just pass the record through without rotation
-                record_rotated = rotate_sequence_to_position(record, rotate_position=0,
+                rotate_value=0
+                record_rotated = rotate_sequence_to_position(record, rotate_position=rotate_value,
                                                              strip_description=strip_descriptions)
 
             # Get values for output report
@@ -399,7 +400,7 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
                                  help='Base pair position to rotate all sequences to (i.e., number of bases to rotate '
                                       'counter-clockwise). To specify a unique rotate position for each sequence, see '
                                       '-t). Incompatible with -m, -P, -t, and -T.')
-    rotate_settings.add_argument('-P', '--rotate_fraction', metavar='INT', required=False, type=int,
+    rotate_settings.add_argument('-P', '--rotate_fraction', metavar='FLOAT', required=False, type=float,
                                  help='Fractional position to rotate all sequences to, counter-clockwise. For example, '
                                       '0.3 means to rotate all contigs counter-clockwise to 30 percent of their total '
                                       'length). To specify a unique fractional position for each sequence, see -T). '

--- a/rotary_utils/rotate.py
+++ b/rotary_utils/rotate.py
@@ -150,7 +150,7 @@ def parse_rotate_value_table(rotate_table_filepath: str, rotate_type: str):
     """
 
     if rotate_type == 'position':
-        expected_column_names = ['sequence_id', 'rotate_position']
+        expected_column_names = ['sequence_id', 'rotate_bp']
     elif rotate_type == 'fraction':
         expected_column_names = ['sequence_id', 'rotate_fraction']
     else:
@@ -408,7 +408,7 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
     rotate_settings.add_argument('-t', '--rotate_position_table', metavar='PATH', required=False, type=str,
                                  help='Path to a tab-separated file that contains the desired amount to rotate each '
                                       'sequence by, in base pair position numbers, in the counter-clockwise direction. '
-                                      'Columns (with headers) should be "sequence_id" and "rotate_position". Only '
+                                      'Columns (with headers) should be "sequence_id" and "rotate_bp". Only '
                                       'sequences specified in the table will be rotated, although all sequences in the '
                                       'input file will be written to the output file. Incompatible with -m, -p, -P, '
                                       'and -T.')

--- a/rotary_utils/rotate.py
+++ b/rotary_utils/rotate.py
@@ -16,38 +16,17 @@ from rotary_utils.utils import set_write_mode, load_fasta_sequences
 logger = logging.getLogger(__name__)
 
 
-# TODO - this is just a placeholder function for now to show some of the features I'd like to add to the CLI later on.
+# TODO: this is just a placeholder function for now to show some of the features I'd like to add to the CLI later on.
 def main(args):
     """
-    Starts the rotate utility
+    Starts the rotate utility.
+
     :param args: args parsed by parse_cli()
     """
 
-    # Startup checks
-    if args.verbose is True:
-        logger.setLevel(logging.DEBUG)
-        logging.getLogger('rotary_utils.utils').setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
-        logging.getLogger('rotary_utils.utils').setLevel(logging.INFO)
-
-    # Check output file
-    # TODO - add overwrite flag
-    # TODO - make this info a function and check all other output files
-    # (TODO - add prefix flag)
-    # TODO - consider also checking if the directory where the output file will be saved exists and is writeable
-    # TODO - include a warning like logger.warning(f'Output file already exists: "{args.output_fasta}". Files may be overwritten.') to the log
-    output_file_exists = os.path.isfile(args.output_fasta)
-
-    if (output_file_exists is True) & (args.overwrite is False):
-
-        logger.error(f'Output file already exists: "{args.output_fasta}". Will not continue. Set the '
-                     f'--overwrite flag at your own risk if you want to overwrite files.')
-        sys.exit(1)
-
     # Parse some command line inputs further
-    # TODO - improve error handling if a string is provided instead of a real length
-    # TODO - confirm what the default value of args.contig_names will be - might need to specify
+    # TODO: improve error handling if a string is provided instead of a real length
+    # TODO: confirm what the default value of args.contig_names will be - might need to specify
     if args.contig_names is not None:
         contig_names = [int(x) for x in args.contig_names.split(',')]
 
@@ -56,36 +35,43 @@ def main(args):
     logger.debug('### SETTINGS ###')
     logger.debug(f'Input FastA: {args.input_fasta}')
     logger.debug(f'Output FastA: {args.output_fasta}')
-    # TODO - finish the rest of the startup messages
+    # TODO: finish the rest of the startup messages
 
     logger.debug(f'Threads: {args.threads}')
     logger.debug(f'Verbose logging: {args.verbose}')
     logger.debug('################')
 
-    # TODO - add rotate code
+    # TODO: add rotate code
 
     logger.info(os.path.basename(sys.argv[0]) + ': done.')
 
 
 def parse_gene_positions():
     """
-    Parses the positions of genes along a contig
-    :return:
+    Parses the positions of genes along a contig.
+
+    :return: table of gene positions
     """
-    # TODO
+    # TODO: this function is a stub.
+
+    pass
 
 
 def avoid_gene_collision():
     """
     Checks if the desired rotation point will collide with a gene and provides an alternative safe point if needed.
+
     :return: The next-nearest position without a collision, with a buffer or on a particular side if requested
     """
-    # TODO
+    # TODO: this function is a stub.
+
+    pass
 
 
 def rotate_sequence(sequence_record: SeqIO.SeqRecord, rotate_position: int, strip_description: bool = True):
     """
-    Rotates an input (circular) sequence to a specified position
+    Rotates an input (circular) sequence to a specified position.
+
     :param sequence_record: BioPython SeqRecord object containing the sequence to rotate
     :param rotate_position: new start position for the contig after rotation (if 0, contig is not rotated)
     :param strip_description: boolean of whether to trim off the read description in the output sequences
@@ -123,7 +109,8 @@ def rotate_sequence(sequence_record: SeqIO.SeqRecord, rotate_position: int, stri
 def rotate_sequence_to_fraction(sequence_record: SeqIO.SeqRecord, rotate_fraction: float,
                                 strip_description: bool = True):
     """
-    Rotates an input (circular) sequence to a specified fraction of the total length
+    Rotates an input (circular) sequence to a specified fraction of the total length.
+
     :param sequence_record: BioPython SeqRecord object containing the sequence to rotate
     :param rotate_fraction: fraction of the contig length to rotate the contig to (rounded down to nearest bp)
     :param strip_description: boolean of whether to trim off the read description in the output sequences
@@ -147,7 +134,8 @@ def rotate_sequence_to_fraction(sequence_record: SeqIO.SeqRecord, rotate_fractio
 
 def rotate_sequence_to_midpoint(sequence_record: SeqIO.SeqRecord, strip_description: bool = True):
     """
-    Rotates an input (circular) sequence to the approximate midpoint
+    Rotates an input (circular) sequence to the approximate midpoint.
+
     :param sequence_record: BioPython SeqRecord object containing the sequence to rotate
     :param strip_description: boolean of whether to trim off the read description in the output sequences
     :return: BioPython SeqRecord object of the rotated FastA file
@@ -155,14 +143,14 @@ def rotate_sequence_to_midpoint(sequence_record: SeqIO.SeqRecord, strip_descript
 
     sequence_record = rotate_sequence_to_fraction(sequence_record, rotate_fraction=0.5,
                                                   strip_description=strip_description)
-
     return sequence_record
 
 
 def rotate_sequences_wf(fasta_filepath: str, output_filepath: str, rotate_positions: dict, append: bool = False,
                         strip_descriptions: bool = True):
     """
-    Rotates all (circular) sequences in an input FastA file to a specified position
+    Rotates all (circular) sequences in an input FastA file to a specified position.
+
     :param fasta_filepath: Path to the FastA file (unzipped) to load. Assumes all entries are circular.
     :param output_filepath: path where the FastA file containing the output rotated contig should be saved
     :param rotate_positions: dict of contig names and new start positions for the contigs after rotation
@@ -189,7 +177,8 @@ def rotate_sequences_wf(fasta_filepath: str, output_filepath: str, rotate_positi
 def rotate_sequences_to_midpoint_wf(fasta_filepath: str, output_filepath: str, append: bool = False,
                                     strip_descriptions: bool = True):
     """
-    Rotates all (circular) sequences in an input FastA file to their midpoint
+    Rotates all (circular) sequences in an input FastA file to their midpoint.
+
     :param fasta_filepath: Path to the FastA file (unzipped) to load. Assumes all entries are circular.
     :param output_filepath: path where the FastA file containing the output rotated contig should be saved
     :param append: whether to append the output FastA onto an existing file (True) or overwrite (False)
@@ -210,33 +199,29 @@ def rotate_sequences_to_midpoint_wf(fasta_filepath: str, output_filepath: str, a
             SeqIO.write(record, output_handle, 'fasta')
 
 
-def parse_cli(subparsers=None):
+def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
     """
-    Parses the CLI arguments
-    :param subparsers An special action object created by argparse's add_subparsers() method.
-                      For example, parser = argparse.ArgumentParser(); subparsers = parser.add_subparsers()
-                      If subparsers is provided, then the new parser is added as a subparser within that object.
-    :return: An argparse parser object
+    Parses the CLI arguments and adds them as a subparser to an existing parser.
+
+    :param subparsers: A special subparser action object created from an existing parser by the add_subparsers() method.
+                       For example, parser = argparse.ArgumentParser(); subparsers = parser.add_subparsers().
+    :param parent_parser: An optional ArgParse object with additional arguments (e.g., shared across all modules) to
+                          add to this CLI parser. This can be a unique parser and does not need to be the parent of the
+                          subparsers object. If None, then no parent will be added for the subparser.
+    :return: An ArgumentParser object created by subparsers.add_parser()
     """
 
     description = """Rotates circular contigs."""
 
-    if subparsers:
-        # Initialize within the provided parser
-        parser = subparsers.add_parser('rotate', help=description)
+    # Initialize within the provided subparser
+    subparser = subparsers.add_parser('rotate', help=description, parents=[parent_parser] if parent_parser else [])
 
-        # Add attribute to tell main() what sub-command was called.
-        parser.set_defaults(rotate=True)
+    # Add attribute to tell main() what sub-command was called.
+    subparser.set_defaults(rotate=True)
 
-    else:
-        parser = argparse.ArgumentParser(
-            description=f'{os.path.basename(sys.argv[0])}: {description} \n'
-                        '  Copyright Jackson M. Tsuji and Lee Bergstrand, 2024',
-            formatter_class=argparse.RawDescriptionHelpFormatter)
-
-    required_settings = parser.add_argument_group('Required')
-    rotate_settings = parser.add_argument_group('Rotate options')
-    workflow_settings = parser.add_argument_group('Workflow options')
+    required_settings = subparser.add_argument_group('Required')
+    rotate_settings = subparser.add_argument_group('Rotate options')
+    workflow_settings = subparser.add_argument_group('Workflow options')
 
     required_settings.add_argument('-i', '--input_fasta', required=True, type=str,
                                    help='Input contig fasta file')
@@ -283,4 +268,4 @@ def parse_cli(subparsers=None):
     workflow_settings.add_argument('-v', '--verbose', required=False, action='store_true',
                                    help='Enable verbose logging to screen')
 
-    return parser
+    return subparser

--- a/rotary_utils/rotate.py
+++ b/rotary_utils/rotate.py
@@ -31,9 +31,9 @@ def main(args):
     logger.debug(f'Output FastA: {args.output_fasta}')
     logger.debug(f'Midpoint rotation: {args.midpoint}')
     logger.debug(f'Constant rotate position: {args.rotate_position}')
-    logger.debug(f'Constant rotate proportion: {args.rotate_proportion}')
+    logger.debug(f'Constant rotate fraction: {args.rotate_fraction}')
     logger.debug(f'Rotate position table: {args.rotate_position_table}')
-    logger.debug(f'Rotate proportion table: {args.rotate_proportion_table}')
+    logger.debug(f'Rotate fraction table: {args.rotate_fraction_table}')
     logger.debug(f'Sequence names to rotate: {args.sequence_names}')
     logger.debug(f'Rotation report: {args.output_report}')
     logger.debug(f'Strip FastA header descriptions: {args.strip_descriptions}')
@@ -62,9 +62,9 @@ def main(args):
                                      rotate_value_single=args.rotate_position, sequence_names=sequence_names,
                                      strip_descriptions=args.strip_descriptions)
 
-    elif args.rotate_proportion is not None:
+    elif args.rotate_fraction is not None:
         report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='fraction',
-                                     rotate_value_single=args.rotate_proportion, sequence_names=sequence_names,
+                                     rotate_value_single=args.rotate_fraction, sequence_names=sequence_names,
                                      strip_descriptions=args.strip_descriptions)
 
     elif args.rotate_position_table is not None:
@@ -74,7 +74,7 @@ def main(args):
                                      rotate_values=rotate_values_dict, sequence_names=sequence_names,
                                      strip_descriptions=args.strip_descriptions)
 
-    elif args.rotate_proportion_table is not None:
+    elif args.rotate_fraction_table is not None:
         rotate_values_dict = parse_rotate_value_table(args.rotate_position_table, rotate_type='fraction')
 
         report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='fraction',
@@ -102,9 +102,9 @@ def check_rotate_args(args):
     1. As described in the README, only one of the following arguments is allowed to be set for a run:
     args.midpoint
     args.rotate_position
-    args.rotate_proportion
+    args.rotate_fraction
     args.rotate_position_table
-    args.rotate_proportion_table
+    args.rotate_fraction_table
     
     2. If overwrite is False, then no output files can already exist:
     args.output_fasta
@@ -112,8 +112,8 @@ def check_rotate_args(args):
     """
 
     # 1. Check rotate value arguments
-    rotate_value_arguments = [args.midpoint, args.rotate_position, args.rotate_proportion, args.rotate_position_table,
-                              args.rotate_proportion_table]
+    rotate_value_arguments = [args.midpoint, args.rotate_position, args.rotate_fraction, args.rotate_position_table,
+                              args.rotate_fraction_table]
 
     defined_arguments = 0
     for argument in rotate_value_arguments:
@@ -149,7 +149,7 @@ def parse_rotate_value_table(rotate_table_filepath: str, rotate_type: str):
     if rotate_type == 'position':
         expected_column_names = ['sequence_id', 'rotate_position']
     elif rotate_type == 'fraction':
-        expected_column_names = ['sequence_id', 'rotate_proportion']
+        expected_column_names = ['sequence_id', 'rotate_fraction']
     else:
         raise ValueError(f'Expected "position" or "fraction", but got "{rotate_type}".')
 
@@ -264,8 +264,8 @@ def rotate_sequences_wf(fasta_filepath: str, output_filepath: str, rotate_type: 
     :param rotate_values: dict of sequence names (keys) and the desired rotation position or fraction for each sequence
                           (values). If rotate_type if 'position', expects the values to be the new start position for
                           each sequence after rotation. If rotate_type if 'fraction', expects the values to be the
-                          fraction (or proportion) of total sequence length to rotate. If the value is set to 0 for a
-                          sequence, then that sequence is not rotated.
+                          fraction of total sequence length to rotate. If the value is set to 0 for a sequence, then
+                          that sequence is not rotated.
     :param rotate_value_single: a single value (position or fraction, depending on rotate_type) to rotate all sequences
                                 to. This is useful if you want to rotate all sequences to their midpoint, for example,
                                 via rotate_value_single=0.5 and rotate_type='fraction'. As a warning, if doing
@@ -379,7 +379,7 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
     rotate_settings.add_argument('-p', '--rotate_position', metavar='INT', required=False, type=int,
                                  help='Base pair position to rotate all sequences to (to specify a unique rotate '
                                       'position for each sequence, see -t). Incompatible with -m, -P, -t, and -T.')
-    rotate_settings.add_argument('-P', '--rotate_proportion', metavar='FRACTION', required=False, type=float,
+    rotate_settings.add_argument('-P', '--rotate_fraction', metavar='FRACTION', required=False, type=float,
                                  help='Fractional position to rotate sequences to (e.g., 0.3 to rotate 30% of total '
                                       'length). To specify a unique fractional position to rotate for each sequence, '
                                       'see -T). Incompatible with -m, -p, -t, and -T.')
@@ -389,10 +389,10 @@ def subparse_cli(subparsers, parent_parser: argparse.ArgumentParser = None):
                                       '"rotate_position". Only sequences specified in the table will be rotated, '
                                       'although all sequences in the input file will be written to the output file. '
                                       'Incompatible with -m, -p, -P, and -T.')
-    rotate_settings.add_argument('-T', '--rotate_proportion_table', metavar='PATH', required=False, type=str,
+    rotate_settings.add_argument('-T', '--rotate_fraction_table', metavar='PATH', required=False, type=str,
                                  help='Path to a tab-separated file that contains the exact fractional positions to '
                                       'rotate each sequence to. Columns (with headers) should be "sequence_id" and '
-                                      '"rotate_proportion". Only sequences specified in the table will be rotated, '
+                                      '"rotate_fraction". Only sequences specified in the table will be rotated, '
                                       'although all sequences in the input file will be written to the output file. '
                                       'Incompatible with -m, -p, -P, and -t.')
     rotate_settings.add_argument('-n', '--sequence_names', metavar='LIST', required=False, type=str, default=None,

--- a/rotary_utils/utils.py
+++ b/rotary_utils/utils.py
@@ -15,23 +15,23 @@ from Bio import SeqIO
 logger = logging.getLogger(__name__)
 
 
-def check_log_file(log_filepath: str, overwrite: bool = False):
+def check_output_file(output_filepath: str, overwrite: bool = False):
     """
-    Checks if OK to create a log file. Raises an error if the log file already exists (unless overwrite=True)
-    :param log_filepath: path to the desired log file
-    :param overwrite: if True, the keep going with a warning if the log file already exists
+    Checks if OK to create an output file. Raises an error if the output file already exists (unless overwrite=True)
+    :param output_filepath: path to the desired output file
+    :param overwrite: if True, the keep going with a warning if the output file already exists
     """
 
-    log_file_exists = os.path.isfile(log_filepath)
+    output_file_exists = os.path.isfile(output_filepath)
 
-    if log_file_exists is True:
+    if output_file_exists is True:
         if overwrite is False:
-            logger.error(f'Log file already exists: "{log_filepath}". Will not continue. Set the '
+            logger.error(f'Output file already exists: "{output_filepath}". Will not continue. Set the '
                          f'--overwrite flag at your own risk if you want to overwrite existing files.')
             sys.exit(1)
 
         elif overwrite is True:
-            logger.warning(f'Log file already exists: "{log_filepath}". File will be overwritten.')
+            logger.warning(f'Output file already exists: "{output_filepath}". File will be overwritten.')
 
         else:
             raise ValueError

--- a/rotary_utils/utils.py
+++ b/rotary_utils/utils.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 def check_output_file(output_filepath: str, overwrite: bool = False):
     """
-    Checks if OK to create an output file. Raises an error if the output file already exists (unless overwrite=True)
+    Checks if OK to create an output file. Raises an error if the output file already exists (unless overwrite=True).
+
     :param output_filepath: path to the desired output file
     :param overwrite: if True, the keep going with a warning if the output file already exists
     """
@@ -39,7 +40,8 @@ def check_output_file(output_filepath: str, overwrite: bool = False):
 
 def set_up_output_directory(output_directory_filepath: str, overwrite: bool = False):
     """
-    Creates an output directory. Raises an error if a directory already exists (unless overwrite=True)
+    Creates an output directory. Raises an error if a directory already exists (unless overwrite=True).
+
     :param output_directory_filepath: path to the desired output directory
     :param overwrite: if True, then keep going with a warning if the output directory already exists
     """
@@ -63,7 +65,8 @@ def set_up_output_directory(output_directory_filepath: str, overwrite: bool = Fa
 
 def get_dependency_version(dependency_name: str, log: bool = False):
     """
-    Tries to get the version of a dependency based on the name of the dependency
+    Tries to get the version of a dependency based on the name of the dependency.
+
     :param dependency_name: name of the dependency
     :param log: is True, print a log of the shell commands used
     :return: version of the dependency. 'unknown' if no version can be parsed
@@ -97,7 +100,8 @@ def get_dependency_version(dependency_name: str, log: bool = False):
 
 def check_dependency(dependency_name: str):
     """
-    Checks if a required shell dependency is present and tries to get its version
+    Checks if a required shell dependency is present and tries to get its version.
+
     :param dependency_name: name of the dependency
     :return: tuple: path to the dependency, dependency version (if available)
     """
@@ -118,6 +122,7 @@ def check_dependency(dependency_name: str):
 def check_dependencies(dependency_names: list):
     """
     For each provided dependency name, checks if the dependency exists and gets the path and version.
+
     :param dependency_names: a list of names of dependencies to check
     :return: a dictionary with dependency names as key and a tuple of dependency paths and versions as values
     """
@@ -137,7 +142,8 @@ def check_dependencies(dependency_names: list):
 
 def set_write_mode(append_log: bool):
     """
-    Converts the boolean append_log to 'w' or 'a' write modes
+    Converts the boolean append_log to 'w' or 'a' write modes.
+
     :param append_log: boolean of whether to append to an existing log file (True) or to overwrite an existing log
                        file (False)
     :return: string of either 'a' (append mode) or 'w' (write mode)
@@ -181,7 +187,7 @@ def run_pipeline_subcommand(command_args, stdin=None, stdout=None, stderr=None, 
 
 def load_fasta_sequences(fasta_filepath: str):
     """
-    Loads an input FastA file as a generator
+    Loads an input FastA file as a generator.
 
     :param fasta_filepath: Path to the FastA file (unzipped) to load
     :return: generator of a SeqRecord object for the loaded sequences


### PR DESCRIPTION
Unfortunately, while making #3, some rotate module code was inadvertently added to the `centralize_code` branch. Now that a basic version of `rotate.py` has been completed, I think it makes sense, for the purpose of code review, to go ahead and merge this basic version with `centralize_code`. That will allow the completed `rotate.py` file to be evaluated along with the other files in the `centralize_code` branch, rather than having only a skeleton version of `rotate.py` there.