### PR TITLE
Develop refactor

### DIFF
--- a/rotary_utils/assembly.py
+++ b/rotary_utils/assembly.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# assembly.py
+# Module containing functions related to processing Flye-based sequence assembly
+# Copyright Jackson M. Tsuji and Lee H. Bergstrand 2024
+
+import logging
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class AssemblyInfo:
+    """
+    A class representing file paths containing info about the input assembly.
+    """
+
+    def __init__(self, assembly_fasta_filepath: str, assembly_info_filepath: str, assembly_info_type: str):
+        """
+        Instantiate an AssemblyInfo object.
+
+        :param assembly_fasta_filepath: path to the assembled contigs output by Flye, FastA format
+        :param assembly_info_filepath: path to assembly_info.txt output by Flye
+        :param assembly_info_type: 'flye' type for assembly_info.txt from flye; 'custom' for custom format (see
+                                   parse_cli for custom format details)
+        """
+        self.assembly_fasta_filepath = assembly_fasta_filepath
+        self.assembly_info_filepath = assembly_info_filepath
+        self.assembly_info_type = assembly_info_type
+
+
+def load_custom_assembly_info_file(assembly_info_filepath: str):
+    """
+    Load and check a custom-format assembly info file.
+
+    :param assembly_info_filepath: path to the custom assembly info file.
+    :return: pandas DataFrame of the assembly info file
+    """
+
+    assembly_info = pd.read_csv(assembly_info_filepath, sep='\t', header=None)
+    assembly_info.columns = ['#seq_name', 'status']
+
+    expected_statuses = {'circular', 'linear'}
+    actual_statuses = set(assembly_info['status'])
+    unexpected_statuses = actual_statuses.difference(expected_statuses)
+
+    if len(unexpected_statuses) != 0:
+        logger.warning(f'Some entries in the assembly info file had unexpected contig status names, i.e.: '
+                       f'{", ".join(unexpected_statuses)}')
+        logger.warning('These entries will be treated as linear contigs... they will not be rotated and will be '
+                       'returned as-is at the end of the script. Please make sure you did not make a typo or '
+                       'include a header for your custom assembly info file.')
+
+    return assembly_info
+
+
+def parse_assembly_info_file(assembly_info_filepath: str, info_type: str):
+    """
+    Extract circular and linear contig names from a Flye (or custom format) assembly info file.
+
+    :param assembly_info_filepath: path to assembly_info.txt output by Flye or a custom assembly info file.
+    :param info_type: whether the info file is in 'flye' format or is a 'custom' format.
+                      'flye' format refers to the 'assembly_info.txt' format output by Flye after a successful assembly.
+                      'custom' info files are tab-separated, have no headers, and have two columns: contig name and
+                      contig type, either 'circular' or 'linear'.
+    :return: tuple containing a list of circular contig names (entry 0) and a list of linear contig names (entry 1).
+    """
+
+    if info_type == 'flye':
+        logger.debug('Loading Flye-format assembly info file')
+        assembly_info = pd.read_csv(assembly_info_filepath, sep='\t')
+        circular_contigs = assembly_info[assembly_info['circ.'] == 'Y']
+        linear_contigs = assembly_info[assembly_info['circ.'] == 'N']
+    elif info_type == 'custom':
+        logger.debug('Loading custom format assembly info file')
+        assembly_info = load_custom_assembly_info_file(assembly_info_filepath)
+        circular_contigs = assembly_info[assembly_info['status'] == 'circular']
+        linear_contigs = assembly_info[assembly_info['status'] != 'circular']
+    else:
+        error = ValueError(f'Assembly info file format should be "flye" or "custom"; you provided {info_type}')
+        logger.error(error)
+        raise error
+
+    # Check for duplicate sequence IDs
+    if assembly_info['#seq_name'].drop_duplicates().shape[0] < assembly_info['#seq_name'].shape[0]:
+        duplicated_ids = set(assembly_info['#seq_name'][assembly_info['#seq_name'].duplicated() == True])
+        error = RuntimeError(f'Some sequence IDs are duplicated in the input assembly info file: '
+                             f'{", ".join(duplicated_ids)}')
+        logger.error(error)
+        raise error
+
+    contig_summary = (list(circular_contigs['#seq_name']), list(linear_contigs['#seq_name']))
+    logger.debug(f'Found {len(contig_summary[0])} circular sequences and {len(contig_summary[1])} linear sequences')
+
+    return contig_summary

--- a/rotary_utils/external.py
+++ b/rotary_utils/external.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+# external.py
+# Code for handling external CLI applications used by rotary-utils (e.g. flye)
+# Copyright Jackson M. Tsuji and Lee H. Bergstrand 2024
+
+import os
+import shlex
+import subprocess
+
+from rotary_utils.repair import logger
+from rotary_utils.utils import set_write_mode, logger
+
+
+def get_dependency_version(dependency_name: str, log: bool = False):
+    """
+    Tries to get the version of a dependency based on the name of the dependency.
+
+    :param dependency_name: name of the dependency
+    :param log: is True, print a log of the shell commands used
+    :return: version of the dependency. 'unknown' if no version can be parsed
+    """
+
+    if dependency_name == 'flye':
+        stdout = run_pipeline_subcommand(['flye', '--version'], stdout=subprocess.PIPE, text=True,
+                                         log=log).stdout
+        dependency_version = stdout.splitlines()[0]
+
+    elif dependency_name == 'minimap2':
+        stdout = run_pipeline_subcommand(['minimap2', '--version'], stdout=subprocess.PIPE, text=True,
+                                         log=log).stdout
+        dependency_version = stdout.splitlines()[0]
+
+    elif dependency_name == 'samtools':
+        stdout = run_pipeline_subcommand(['samtools', 'version'], stdout=subprocess.PIPE, text=True,
+                                         log=log).stdout
+        dependency_version = stdout.splitlines()[0].split(' ')[1]
+
+    elif dependency_name == 'circlator':
+        stdout = run_pipeline_subcommand(['circlator', 'version'], stdout=subprocess.PIPE, text=True,
+                                         log=log).stdout
+        dependency_version = stdout.splitlines()[0]
+
+    else:
+        dependency_version = 'unknown'
+
+    return dependency_version
+
+
+def run_pipeline_subcommand(command_args, stdin=None, stdout=None, stderr=None, check=True, text=None, log=True):
+    """
+    Wrapper function for running subcommands.
+
+    :param command_args: The command line arguments of the subcommand (e.g., ['samtools', '-h'])
+    :param stdin: A subprocess.PIPE or None if stdin is not to be used.
+    :param stdout: Where to send stdout or None if stdout is not to be used.
+    :param stderr: Where to send stderr or None if stderr is not to be used.
+    :param check: Cause a runtime error if the subcommand fails.
+    :param text: If True, open outputs in text mode (rather than binary)
+    :param log: If True, write the shell command to logger in debug mode
+    :return: The output of the subcommand.
+    """
+
+    if log is True:
+        logger.debug(shlex.join(command_args))
+    if stdin:
+        stdin = stdin.stdout
+
+    return subprocess.run(command_args, check=check, input=stdin, stdout=stdout, stderr=stderr, text=text)
+
+
+def map_long_reads(contig_filepath: str, long_read_filepath: str, output_bam_filepath: str, log_filepath: str,
+                   append_log: bool = True, threads: int = 1, threads_mem_mb: float = 1):
+    """
+    Maps long reads (via minimap2) to contigs and sorts/indexes the resulting BAM file. output_bam_filepath and
+    log_filepath are saved to disk.
+
+    :param contig_filepath: path to the FastA file containing the reference contigs
+    :param long_read_filepath: path to the FastQ file containing long reads to map (compressed is OK)
+    :param output_bam_filepath: path to the BAM file to be saved
+    :param log_filepath: path to the log file to be saved
+    :param append_log: whether the log should append to an existing file (True) or overwrite an existing file (False);
+                       this setting is only relevant if the log file at log_filepath already exists
+    :param threads: number of threads to use for read mapping
+    :param threads_mem_mb: memory in MB per thread (to use for samtools); must be an integer
+    """
+
+    write_mode = set_write_mode(append_log)
+
+    with open(log_filepath, write_mode) as logfile_handle:
+        with open(output_bam_filepath, 'w') as bam_handle:
+            # TODO - add support for different flags like -ax for pacbio
+            minimap_args = ['minimap2', '-t', str(threads), '-ax', 'map-ont', contig_filepath, long_read_filepath]
+            minimap = run_pipeline_subcommand(command_args=minimap_args, stdout=subprocess.PIPE, stderr=logfile_handle)
+
+            samtools_view_args = ['samtools', 'view', '-b', '-@', str(threads)]
+            samtools_view = run_pipeline_subcommand(command_args=samtools_view_args, stdin=minimap,
+                                                    stdout=subprocess.PIPE, stderr=logfile_handle)
+
+            samtools_sort_args = ['samtools', 'sort', '-@', str(threads), '-m', f'{threads_mem_mb}M']
+            run_pipeline_subcommand(command_args=samtools_sort_args, stdin=samtools_view, stdout=bam_handle,
+                                    stderr=logfile_handle)
+
+        samtools_index_args = ['samtools', 'index', '-@', str(threads), output_bam_filepath]
+        run_pipeline_subcommand(command_args=samtools_index_args, stderr=logfile_handle)
+
+    logger.debug('Read mapping finished')
+
+
+def subset_reads_from_bam(bam_filepath: str, bed_filepath: str, subset_fastq_filepath: str, log_filepath: str,
+                          append_log: bool = True, threads: int = 1):
+    """
+    Subsets reads from a BAM file that were mapped to regions defined in a BED file; saves reads to a FastQ file, at
+    filepath subset_fastq_filepath.
+
+    :param bam_filepath: path to a BAM file containing reads mapped to a reference; BAM needs to be sorted and indexed
+    :param bed_filepath: path to a BED file containing the regions of reference contigs to subset reads for
+    :param subset_fastq_filepath: path to the FastQ file to be saved (.fastq.gz extension saves as Gzipped FastQ)
+    :param log_filepath: path to the log file to be saved
+    :param append_log: whether the log should append to an existing file (True) or overwrite an existing file (False);
+                       this setting is only relevant if the log file at log_filepath already exists
+    :param threads: number of threads to use for read mapping
+    """
+
+    write_mode = set_write_mode(append_log)
+
+    with open(log_filepath, write_mode) as logfile_handle:
+        # TODO - consider adding option to split long reads in half if they go around a short circular contig,
+        #  like in circlator
+        samtools_view_args = ['samtools', 'view', '-@', str(threads), '-L', bed_filepath, '-b', bam_filepath]
+        samtools_view = run_pipeline_subcommand(command_args=samtools_view_args, stdout=subprocess.PIPE,
+                                                stderr=logfile_handle)
+
+        samtools_fastq_args = ['samtools', 'fastq', '-0', subset_fastq_filepath, '-n', '-@', str(threads)]
+        run_pipeline_subcommand(command_args=samtools_fastq_args, stdin=samtools_view, stderr=logfile_handle)
+
+
+def run_flye(fastq_filepath: str, flye_outdir: str, flye_read_mode: str, flye_read_error: float, log_filepath: str,
+             append_log: bool = True, threads: int = 1):
+    """
+    Runs Flye to assemble the reads in the input FastQ file. This function allows Flye to fail without raising an error.
+
+    :param fastq_filepath: path to a FastQ file containing the input reads (gzipped is OK)
+    :param flye_outdir: directory to save Flye output to
+    :param flye_read_mode: type of long reads, either 'nano-raw' or 'nano-hq'
+    :param flye_read_error: expected error rate of reads as a proportion; specify 0 to use default Flye settings
+    :param log_filepath: path to the log file to be saved
+    :param append_log: whether the log should append to an existing file (True) or overwrite an existing file (False);
+                       this setting is only relevant if the log file at log_filepath already exists
+    :param threads: number of threads to use for read mapping
+    :return: return code of Flye (0 if it finished successfully).
+    """
+
+    # TODO - add support for PacBio reads
+    if (flye_read_mode != 'nano-raw') & (flye_read_mode != 'nano-hq'):
+        error = ValueError(f'flye_read_mode must be "nano-raw" or "nano-hq"; you provided {flye_read_mode}')
+        logger.error(error)
+        raise error
+
+    flye_args = ['flye', f'--{flye_read_mode}', fastq_filepath, '-o', flye_outdir, '-t', str(threads)]
+
+    if flye_read_error != 0:
+        flye_args.append('--read_error')
+        flye_args.append(flye_read_error)
+
+    write_mode = set_write_mode(append_log)
+    with open(log_filepath, write_mode) as logfile_handle:
+        flye_run = run_pipeline_subcommand(command_args=flye_args, check=False, stderr=logfile_handle)
+
+    if flye_run.returncode != 0:
+        logger.warning(f'Flye did not finish successfully; see log for details at "{log_filepath}"')
+
+    return flye_run.returncode
+
+
+def run_circlator_merge(circular_contig_filepath: str, patch_contig_filepath: str, merge_outdir: str,
+                        circlator_min_id: float, circlator_min_length: int, circlator_ref_end: int,
+                        circlator_reassemble_end: int, log_filepath: str, append_log: bool = True):
+    """
+    Runs the 'circlator merge' module to stitch a gap-spanning contig onto the ends of a circular contig to confirm and
+    repair the circularization of the contig. 'circlator merge' output is saved to disk at merge_outdir
+
+    :param circular_contig_filepath: path to a FastA file containing the original (non-stitched) circular contig
+    :param patch_contig_filepath: path to a FastA file containing a linear contig that should span the 'ends' of the
+                                  circular contig
+    :param merge_outdir: directory to save circlator merge output to
+    :param circlator_min_id: Percent identity threshold for circlator merge to stitch the contigs
+    :param circlator_min_length: Minimum required overlap (bp) between the circular contig and the patch contig
+    :param circlator_ref_end: Minimum distance (bp) between end of circular contig and the nucmer hit
+    :param circlator_reassemble_end: Minimum distance (bp) between end of patch contig and the nucmer hit
+    :param log_filepath: path to the log file to be saved
+    :param append_log: whether the log should append to an existing file (True) or overwrite an existing file (False);
+                       this setting is only relevant if the log file at log_filepath already exists
+    """
+
+    os.makedirs(merge_outdir, exist_ok=True)
+
+    write_mode = set_write_mode(append_log)
+    with open(log_filepath, write_mode) as logfile_handle:
+        circlator_merge_args = ['circlator', 'merge', '--verbose', '--min_id', str(circlator_min_id),
+                                '--min_length', str(circlator_min_length), '--ref_end', str(circlator_ref_end),
+                                '--reassemble_end', str(circlator_reassemble_end), circular_contig_filepath,
+                                patch_contig_filepath, os.path.join(merge_outdir, 'merge')]
+        run_pipeline_subcommand(command_args=circlator_merge_args, stdout=logfile_handle, stderr=subprocess.STDOUT)
+
+
+def check_circlator_success(circlator_logfile: str):
+    """
+    Checks the circlator log file to see if contig stitching was successful.
+
+    :param circlator_logfile: path to the circlator log file
+    :return: Boolean of whether the contigs were successfully stitched or not
+    """
+
+    logger.debug('Loading circlator logfile')
+    circlator_info = pd.read_csv(circlator_logfile, sep='\t')[['#Contig', 'circularised']]
+
+    # TODO: I think I might be able to safely just look for if the sum is 1 (>1 might mean something odd happened)
+    # If a row is '1', it means it was stitched properly, but if '0', it means it was not stitched.
+    # So if all rows are 1 (i.e., the sum of rows / # of rows is 1), it means everything was stitched properly.
+    if circlator_info['circularised'].sum() / circlator_info.shape[0] == 1:
+        logger.debug('Everything is stitched.')
+        result = True
+    elif circlator_info['circularised'].sum() >= 0:
+        logger.debug('Not everything is stitched.')
+        result = False
+    else:
+        error = RuntimeError(f'Could not understand the circularization status output by circlator: '
+                             f'{circlator_info.shape[0]} rows, but the sum of circularization status of these rows is '
+                             f'{circlator_info["circularised"].sum()} (should be >=0, because each row should have a'
+                             f'status of either 0 or 1).')
+        logger.error(error)
+        raise error
+
+    return result

--- a/rotary_utils/external.py
+++ b/rotary_utils/external.py
@@ -15,6 +15,7 @@ from rotary_utils.utils import set_write_mode
 
 logger = logging.getLogger(__name__)
 
+
 def check_dependency(dependency_name: str):
     """
     Checks if a required shell dependency is present and tries to get its version.
@@ -55,38 +56,32 @@ def check_dependencies(dependency_names: list):
 
     return dependency_dict
 
+
 def get_dependency_version(dependency_name: str, log: bool = False):
     """
     Tries to get the version of a dependency based on the name of the dependency.
-
     :param dependency_name: name of the dependency
     :param log: is True, print a log of the shell commands used
     :return: version of the dependency. 'unknown' if no version can be parsed
     """
+    version_commands = {
+        'flye': ['flye', '--version'],
+        'minimap2': ['minimap2', '--version'],
+        'samtools': ['samtools', 'version'],
+        'circlator': ['circlator', 'version'],
+    }
 
-    if dependency_name == 'flye':
-        stdout = run_pipeline_subcommand(['flye', '--version'], stdout=subprocess.PIPE, text=True,
-                                         log=log).stdout
-        dependency_version = stdout.splitlines()[0]
+    if dependency_name in version_commands:
+        stdout = run_pipeline_subcommand(version_commands[dependency_name], stdout=subprocess.PIPE,
+                                         text=True, log=log).stdout
 
-    elif dependency_name == 'minimap2':
-        stdout = run_pipeline_subcommand(['minimap2', '--version'], stdout=subprocess.PIPE, text=True,
-                                         log=log).stdout
-        dependency_version = stdout.splitlines()[0]
-
-    elif dependency_name == 'samtools':
-        stdout = run_pipeline_subcommand(['samtools', 'version'], stdout=subprocess.PIPE, text=True,
-                                         log=log).stdout
-        dependency_version = stdout.splitlines()[0].split(' ')[1]
-
-    elif dependency_name == 'circlator':
-        stdout = run_pipeline_subcommand(['circlator', 'version'], stdout=subprocess.PIPE, text=True,
-                                         log=log).stdout
-        dependency_version = stdout.splitlines()[0]
-
+        # Special parsing is needed for samtools output.
+        if dependency_name == 'samtools':
+            dependency_version = stdout.splitlines()[0].split(' ')[1]
+        else:
+            dependency_version = stdout.splitlines()[0]
     else:
         dependency_version = 'unknown'
-
     return dependency_version
 
 
@@ -276,5 +271,3 @@ def check_circlator_success(circlator_logfile: str):
         raise error
 
     return result
-
-

--- a/rotary_utils/external.py
+++ b/rotary_utils/external.py
@@ -10,7 +10,6 @@ import subprocess
 
 import pandas as pd
 
-from rotary_utils.repair import logger
 from rotary_utils.utils import set_write_mode
 
 logger = logging.getLogger(__name__)

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -153,8 +153,6 @@ class StitchDirectories:
         Description of constant attributes:
             linking_outdir: output directory for the overall analysis.
             log_dir_base: directory where key log files will be saved.
-            length_outdir: output directory for a specific length threshold.
-            log_dir: directory where log files for a specific length threshold will be saved.
         """
         self.linking_outdir = linking_outdir
         self.log_dir_base = os.path.join(linking_outdir, 'logs')
@@ -182,7 +180,7 @@ class StitchDirectories:
     @property
     def length_outdir(self):
         """
-        A property representing a length directory path.
+        A property representing a path to the output directory for a specific length threshold.
         """
         if self.length_threshold:
             length_outdir = os.path.join(self.linking_outdir, f'L{self.length_threshold}')
@@ -194,7 +192,7 @@ class StitchDirectories:
     @property
     def log_dir(self):
         """
-        A property representing a log directory path.
+        A property representing a path to the directory where log files for a specific length threshold will be saved.
         """
         if self.length_threshold:
             log_dir = os.path.join(self.log_dir_base, f'L{self.length_threshold}')

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -7,14 +7,15 @@ import argparse
 import logging
 import os
 import shutil
-import subprocess
 import sys
 
 import pandas as pd
 from Bio import SeqIO
 
-from rotary_utils.utils import check_dependencies, run_pipeline_subcommand, set_write_mode, load_fasta_sequences
+from rotary_utils.external import map_long_reads, subset_reads_from_bam, run_flye, run_circlator_merge, \
+    check_circlator_success
 from rotary_utils.rotate import rotate_sequences_wf
+from rotary_utils.utils import check_dependencies, load_fasta_sequences
 
 # GLOBAL VARIABLES
 DEPENDENCY_NAMES = ['flye', 'minimap2', 'samtools', 'circlator']
@@ -197,172 +198,6 @@ def generate_bed_file(contig_seqrecord: SeqIO.SeqRecord, bed_filepath: str, leng
     end_regions = pd.DataFrame({'contig': contigs, 'start': starts, 'stop': stops})
 
     end_regions.to_csv(bed_filepath, sep='\t', header=None, index=False)
-
-
-def map_long_reads(contig_filepath: str, long_read_filepath: str, output_bam_filepath: str, log_filepath: str,
-                   append_log: bool = True, threads: int = 1, threads_mem_mb: float = 1):
-    """
-    Maps long reads (via minimap2) to contigs and sorts/indexes the resulting BAM file. output_bam_filepath and
-    log_filepath are saved to disk.
-
-    :param contig_filepath: path to the FastA file containing the reference contigs
-    :param long_read_filepath: path to the FastQ file containing long reads to map (compressed is OK)
-    :param output_bam_filepath: path to the BAM file to be saved
-    :param log_filepath: path to the log file to be saved
-    :param append_log: whether the log should append to an existing file (True) or overwrite an existing file (False);
-                       this setting is only relevant if the log file at log_filepath already exists
-    :param threads: number of threads to use for read mapping
-    :param threads_mem_mb: memory in MB per thread (to use for samtools); must be an integer
-    """
-
-    write_mode = set_write_mode(append_log)
-
-    with open(log_filepath, write_mode) as logfile_handle:
-        with open(output_bam_filepath, 'w') as bam_handle:
-            # TODO - add support for different flags like -ax for pacbio
-            minimap_args = ['minimap2', '-t', str(threads), '-ax', 'map-ont', contig_filepath, long_read_filepath]
-            minimap = run_pipeline_subcommand(command_args=minimap_args, stdout=subprocess.PIPE, stderr=logfile_handle)
-
-            samtools_view_args = ['samtools', 'view', '-b', '-@', str(threads)]
-            samtools_view = run_pipeline_subcommand(command_args=samtools_view_args, stdin=minimap,
-                                                    stdout=subprocess.PIPE, stderr=logfile_handle)
-
-            samtools_sort_args = ['samtools', 'sort', '-@', str(threads), '-m', f'{threads_mem_mb}M']
-            run_pipeline_subcommand(command_args=samtools_sort_args, stdin=samtools_view, stdout=bam_handle,
-                                    stderr=logfile_handle)
-
-        samtools_index_args = ['samtools', 'index', '-@', str(threads), output_bam_filepath]
-        run_pipeline_subcommand(command_args=samtools_index_args, stderr=logfile_handle)
-
-    logger.debug('Read mapping finished')
-
-
-def subset_reads_from_bam(bam_filepath: str, bed_filepath: str, subset_fastq_filepath: str, log_filepath: str,
-                          append_log: bool = True, threads: int = 1):
-    """
-    Subsets reads from a BAM file that were mapped to regions defined in a BED file; saves reads to a FastQ file, at
-    filepath subset_fastq_filepath.
-
-    :param bam_filepath: path to a BAM file containing reads mapped to a reference; BAM needs to be sorted and indexed
-    :param bed_filepath: path to a BED file containing the regions of reference contigs to subset reads for
-    :param subset_fastq_filepath: path to the FastQ file to be saved (.fastq.gz extension saves as Gzipped FastQ)
-    :param log_filepath: path to the log file to be saved
-    :param append_log: whether the log should append to an existing file (True) or overwrite an existing file (False);
-                       this setting is only relevant if the log file at log_filepath already exists
-    :param threads: number of threads to use for read mapping
-    """
-
-    write_mode = set_write_mode(append_log)
-
-    with open(log_filepath, write_mode) as logfile_handle:
-        # TODO - consider adding option to split long reads in half if they go around a short circular contig,
-        #  like in circlator
-        samtools_view_args = ['samtools', 'view', '-@', str(threads), '-L', bed_filepath, '-b', bam_filepath]
-        samtools_view = run_pipeline_subcommand(command_args=samtools_view_args, stdout=subprocess.PIPE,
-                                                stderr=logfile_handle)
-
-        samtools_fastq_args = ['samtools', 'fastq', '-0', subset_fastq_filepath, '-n', '-@', str(threads)]
-        run_pipeline_subcommand(command_args=samtools_fastq_args, stdin=samtools_view, stderr=logfile_handle)
-
-
-def run_flye(fastq_filepath: str, flye_outdir: str, flye_read_mode: str, flye_read_error: float, log_filepath: str,
-             append_log: bool = True, threads: int = 1):
-    """
-    Runs Flye to assemble the reads in the input FastQ file. This function allows Flye to fail without raising an error.
-
-    :param fastq_filepath: path to a FastQ file containing the input reads (gzipped is OK)
-    :param flye_outdir: directory to save Flye output to
-    :param flye_read_mode: type of long reads, either 'nano-raw' or 'nano-hq'
-    :param flye_read_error: expected error rate of reads as a proportion; specify 0 to use default Flye settings
-    :param log_filepath: path to the log file to be saved
-    :param append_log: whether the log should append to an existing file (True) or overwrite an existing file (False);
-                       this setting is only relevant if the log file at log_filepath already exists
-    :param threads: number of threads to use for read mapping
-    :return: return code of Flye (0 if it finished successfully).
-    """
-
-    # TODO - add support for PacBio reads
-    if (flye_read_mode != 'nano-raw') & (flye_read_mode != 'nano-hq'):
-        error = ValueError(f'flye_read_mode must be "nano-raw" or "nano-hq"; you provided {flye_read_mode}')
-        logger.error(error)
-        raise error
-
-    flye_args = ['flye', f'--{flye_read_mode}', fastq_filepath, '-o', flye_outdir, '-t', str(threads)]
-
-    if flye_read_error != 0:
-        flye_args.append('--read_error')
-        flye_args.append(flye_read_error)
-
-    write_mode = set_write_mode(append_log)
-    with open(log_filepath, write_mode) as logfile_handle:
-        flye_run = run_pipeline_subcommand(command_args=flye_args, check=False, stderr=logfile_handle)
-
-    if flye_run.returncode != 0:
-        logger.warning(f'Flye did not finish successfully; see log for details at "{log_filepath}"')
-
-    return flye_run.returncode
-
-
-def run_circlator_merge(circular_contig_filepath: str, patch_contig_filepath: str, merge_outdir: str,
-                        circlator_min_id: float, circlator_min_length: int, circlator_ref_end: int,
-                        circlator_reassemble_end: int, log_filepath: str, append_log: bool = True):
-    """
-    Runs the 'circlator merge' module to stitch a gap-spanning contig onto the ends of a circular contig to confirm and
-    repair the circularization of the contig. 'circlator merge' output is saved to disk at merge_outdir
-
-    :param circular_contig_filepath: path to a FastA file containing the original (non-stitched) circular contig
-    :param patch_contig_filepath: path to a FastA file containing a linear contig that should span the 'ends' of the
-                                  circular contig
-    :param merge_outdir: directory to save circlator merge output to
-    :param circlator_min_id: Percent identity threshold for circlator merge to stitch the contigs
-    :param circlator_min_length: Minimum required overlap (bp) between the circular contig and the patch contig
-    :param circlator_ref_end: Minimum distance (bp) between end of circular contig and the nucmer hit
-    :param circlator_reassemble_end: Minimum distance (bp) between end of patch contig and the nucmer hit
-    :param log_filepath: path to the log file to be saved
-    :param append_log: whether the log should append to an existing file (True) or overwrite an existing file (False);
-                       this setting is only relevant if the log file at log_filepath already exists
-    """
-
-    os.makedirs(merge_outdir, exist_ok=True)
-
-    write_mode = set_write_mode(append_log)
-    with open(log_filepath, write_mode) as logfile_handle:
-        circlator_merge_args = ['circlator', 'merge', '--verbose', '--min_id', str(circlator_min_id),
-                                '--min_length', str(circlator_min_length), '--ref_end', str(circlator_ref_end),
-                                '--reassemble_end', str(circlator_reassemble_end), circular_contig_filepath,
-                                patch_contig_filepath, os.path.join(merge_outdir, 'merge')]
-        run_pipeline_subcommand(command_args=circlator_merge_args, stdout=logfile_handle, stderr=subprocess.STDOUT)
-
-
-def check_circlator_success(circlator_logfile: str):
-    """
-    Checks the circlator log file to see if contig stitching was successful.
-
-    :param circlator_logfile: path to the circlator log file
-    :return: Boolean of whether the contigs were successfully stitched or not
-    """
-
-    logger.debug('Loading circlator logfile')
-    circlator_info = pd.read_csv(circlator_logfile, sep='\t')[['#Contig', 'circularised']]
-
-    # TODO: I think I might be able to safely just look for if the sum is 1 (>1 might mean something odd happened)
-    # If a row is '1', it means it was stitched properly, but if '0', it means it was not stitched.
-    # So if all rows are 1 (i.e., the sum of rows / # of rows is 1), it means everything was stitched properly.
-    if circlator_info['circularised'].sum() / circlator_info.shape[0] == 1:
-        logger.debug('Everything is stitched.')
-        result = True
-    elif circlator_info['circularised'].sum() >= 0:
-        logger.debug('Not everything is stitched.')
-        result = False
-    else:
-        error = RuntimeError(f'Could not understand the circularization status output by circlator: '
-                             f'{circlator_info.shape[0]} rows, but the sum of circularization status of these rows is '
-                             f'{circlator_info["circularised"].sum()} (should be >=0, because each row should have a'
-                             f'status of either 0 or 1).')
-        logger.error(error)
-        raise error
-
-    return result
 
 
 def link_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: str, length_outdir: str, length_threshold: int,

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -15,6 +15,7 @@ from Bio import SeqIO
 from rotary_utils.external import map_long_reads, subset_reads_from_bam, run_flye, run_circlator_merge, \
     check_circlator_success, check_dependencies
 from rotary_utils.rotate import rotate_sequences_wf
+from rotary_utils.assembly import AssemblyInfo, parse_assembly_info_file
 from rotary_utils.utils import subset_sequences
 
 # GLOBAL VARIABLES
@@ -103,25 +104,6 @@ class RepairToolSettings:
         self.threads = threads
         # Convert GB to nearest whole-number MB value (must be an integer for samtools)
         self.threads_mem_mb = int(threads_mem * 1024)
-
-
-class AssemblyInfo:
-    """
-    A class representing file paths containing info about the input assembly.
-    """
-
-    def __init__(self, assembly_fasta_filepath: str, assembly_info_filepath: str, assembly_info_type: str):
-        """
-        Instantiate an AssemblyInfo object.
-
-        :param assembly_fasta_filepath: path to the assembled contigs output by Flye, FastA format
-        :param assembly_info_filepath: path to assembly_info.txt output by Flye
-        :param assembly_info_type: 'flye' type for assembly_info.txt from flye; 'custom' for custom format (see
-                                   parse_cli for custom format details)
-        """
-        self.assembly_fasta_filepath = assembly_fasta_filepath
-        self.assembly_info_filepath = assembly_info_filepath
-        self.assembly_info_type = assembly_info_type
 
 
 class RepairPaths:
@@ -227,72 +209,6 @@ class ContigInfo:
         self.repaired_contig_names = list(set(circular_contig_names).difference(set(failed_contig_names)))
         self.failed_contig_names = failed_contig_names
         self.linear_contig_names = linear_contig_names
-
-
-def load_custom_assembly_info_file(assembly_info_filepath: str):
-    """
-    Load and check a custom-format assembly info file.
-
-    :param assembly_info_filepath: path to the custom assembly info file.
-    :return: pandas DataFrame of the assembly info file
-    """
-
-    assembly_info = pd.read_csv(assembly_info_filepath, sep='\t', header=None)
-    assembly_info.columns = ['#seq_name', 'status']
-
-    expected_statuses = {'circular', 'linear'}
-    actual_statuses = set(assembly_info['status'])
-    unexpected_statuses = actual_statuses.difference(expected_statuses)
-
-    if len(unexpected_statuses) != 0:
-        logger.warning(f'Some entries in the assembly info file had unexpected contig status names, i.e.: '
-                       f'{", ".join(unexpected_statuses)}')
-        logger.warning('These entries will be treated as linear contigs... they will not be rotated and will be '
-                       'returned as-is at the end of the script. Please make sure you did not make a typo or '
-                       'include a header for your custom assembly info file.')
-
-    return assembly_info
-
-
-def parse_assembly_info_file(assembly_info_filepath: str, info_type: str):
-    """
-    Extract circular and linear contig names from a Flye (or custom format) assembly info file.
-
-    :param assembly_info_filepath: path to assembly_info.txt output by Flye or a custom assembly info file.
-    :param info_type: whether the info file is in 'flye' format or is a 'custom' format.
-                      'flye' format refers to the 'assembly_info.txt' format output by Flye after a successful assembly.
-                      'custom' info files are tab-separated, have no headers, and have two columns: contig name and
-                      contig type, either 'circular' or 'linear'.
-    :return: tuple containing a list of circular contig names (entry 0) and a list of linear contig names (entry 1).
-    """
-
-    if info_type == 'flye':
-        logger.debug('Loading Flye-format assembly info file')
-        assembly_info = pd.read_csv(assembly_info_filepath, sep='\t')
-        circular_contigs = assembly_info[assembly_info['circ.'] == 'Y']
-        linear_contigs = assembly_info[assembly_info['circ.'] == 'N']
-    elif info_type == 'custom':
-        logger.debug('Loading custom format assembly info file')
-        assembly_info = load_custom_assembly_info_file(assembly_info_filepath)
-        circular_contigs = assembly_info[assembly_info['status'] == 'circular']
-        linear_contigs = assembly_info[assembly_info['status'] != 'circular']
-    else:
-        error = ValueError(f'Assembly info file format should be "flye" or "custom"; you provided {info_type}')
-        logger.error(error)
-        raise error
-
-    # Check for duplicate sequence IDs
-    if assembly_info['#seq_name'].drop_duplicates().shape[0] < assembly_info['#seq_name'].shape[0]:
-        duplicated_ids = set(assembly_info['#seq_name'][assembly_info['#seq_name'].duplicated() == True])
-        error = RuntimeError(f'Some sequence IDs are duplicated in the input assembly info file: '
-                             f'{", ".join(duplicated_ids)}')
-        logger.error(error)
-        raise error
-
-    contig_summary = (list(circular_contigs['#seq_name']), list(linear_contigs['#seq_name']))
-    logger.debug(f'Found {len(contig_summary[0])} circular sequences and {len(contig_summary[1])} linear sequences')
-
-    return contig_summary
 
 
 def generate_bed_file(contig_seqrecord: SeqIO.SeqRecord, bed_filepath: str, length_threshold: int = 100000):

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -34,13 +34,11 @@ def main(args):
     assembly_info_type = 'custom' if args.custom_assembly_info_file is True else 'flye'
     # TODO - improve error handling if a string is provided instead of a real length
     length_thresholds = [int(x) for x in args.length_thresholds.split(',')]
-    cli_tool_settings_dict = {'flye_read_mode': args.flye_read_mode,
-                              'flye_read_error': args.flye_read_error,
-                              'circlator_min_id': args.circlator_min_id,
-                              'circlator_min_length': args.circlator_min_length,
-                              'circlator_ref_end': args.circlator_ref_end,
-                              'circlator_reassemble_end': args.circlator_reassemble_end}
-    threads_mem_mb = int(args.threads_mem * 1024)
+    tool_settings = ToolSettings(flye_read_mode=args.flye_read_mode, flye_read_error=args.flye_read_error,
+                                 circlator_min_id=args.circlator_min_id, circlator_min_length=args.circlator_min_length,
+                                 circlator_ref_end=args.circlator_ref_end,
+                                 circlator_reassemble_end=args.circlator_reassemble_end,
+                                 threads=args.threads, threads_mem=args.threads_mem)
 
     # Startup messages
     logger.info('Running ' + os.path.basename(sys.argv[0]))
@@ -55,24 +53,55 @@ def main(args):
     logger.debug(f'Overwrite output dir if needed?: {args.overwrite}')
     logger.debug(f'Length thresholds to test (bp): {length_thresholds}')
     logger.debug(f'Keep going if some contigs cannot be re-circularized?: {args.keep_going_with_failed_contigs}')
-    logger.debug(f'Flye read mode: {cli_tool_settings_dict["flye_read_mode"]}')
-    logger.debug(f'Flye read error: {cli_tool_settings_dict["flye_read_error"]}')
-    logger.debug(f'Circlator min. ID: {cli_tool_settings_dict["circlator_min_id"]}')
-    logger.debug(f'Circlator min. length: {cli_tool_settings_dict["circlator_min_length"]}')
-    logger.debug(f'Circlator ref. end: {cli_tool_settings_dict["circlator_ref_end"]}')
-    logger.debug(f'Circlator reassembly end: {cli_tool_settings_dict["circlator_reassemble_end"]}')
+    logger.debug(f'Flye read mode: {tool_settings.flye_read_mode}')
+    logger.debug(f'Flye read error: {tool_settings.flye_read_error}')
+    logger.debug(f'Circlator min. ID: {tool_settings.circlator_min_id}')
+    logger.debug(f'Circlator min. length: {tool_settings.circlator_min_length}')
+    logger.debug(f'Circlator ref. end: {tool_settings.circlator_ref_end}')
+    logger.debug(f'Circlator reassembly end: {tool_settings.circlator_reassemble_end}')
     logger.debug(f'Custom log file path: {args.logfile}')
-    logger.debug(f'Threads: {args.threads}')
-    logger.debug(f'Memory per thread (GB = MB): {args.threads_mem} = {threads_mem_mb}')
+    logger.debug(f'Threads: {tool_settings.threads}')
+    logger.debug(f'Memory per thread (GB = MB): {args.threads_mem} = {tool_settings.threads_mem_mb}')
     logger.debug(f'Verbose logging: {args.verbose}')
     logger.debug('################')
 
     assembly_info = AssemblyInfo(args.assembly_fasta_filepath, args.assembly_info_filepath, assembly_info_type)
-
     run_end_repair(args.long_read_filepath, assembly_info, args.output_dir, length_thresholds,
-                   args.keep_going_with_failed_contigs, cli_tool_settings_dict, args.threads, threads_mem_mb)
+                   args.keep_going_with_failed_contigs, tool_settings)
 
     logger.info(os.path.basename(sys.argv[0]) + ': done.')
+
+
+class ToolSettings:
+    """
+    A class representing settings for tools used in the repair workflow.
+    """
+
+    def __init__(self, flye_read_mode: str, flye_read_error: float, circlator_min_id: float, circlator_min_length: int,
+                 circlator_ref_end: int, circlator_reassemble_end: int, threads: int, threads_mem: float):
+        """
+        Instantiate an AssemblyInfo object.
+
+        :param flye_read_mode: type of long read reads to be used for reassembly by Flye. See details in the Flye
+                               documentation. Currently, nano-hq and nano-raw are available.
+        :param flye_read_error: expected error rate of input reads, expressed as proportion (e.g., 0.03). If "0", then
+                                flye will set the read error automatically.
+        :param circlator_min_id: percent identity threshold for circlator merge.
+        :param circlator_min_length: minimum required overlap (bp) between original and merge contigs.
+        :param circlator_ref_end: minimum distance (bp) between end of original contig and nucmer hit
+        :param circlator_reassemble_end: minimum distance (bp) between end of merge contig and nucmer hit
+        :param threads: number of parallel processes to use for analysis, where parallel processing is possible.
+        :param threads_mem: memory to use **per thread** for samtools sort, in gigabytes (GB)
+        """
+        self.flye_read_mode = flye_read_mode
+        self.flye_read_error = flye_read_error
+        self.circlator_min_id = circlator_min_id
+        self.circlator_min_length = circlator_min_length
+        self.circlator_ref_end = circlator_ref_end
+        self.circlator_reassemble_end = circlator_reassemble_end
+        self.threads = threads
+        # Convert GB to nearest whole-number MB value (must be an integer for samtools)
+        self.threads_mem_mb = int(threads_mem * 1024)
 
 
 class AssemblyInfo:
@@ -262,7 +291,7 @@ def generate_bed_file(contig_seqrecord: SeqIO.SeqRecord, bed_filepath: str, leng
 
 
 def link_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: str, length_outdir: str, length_threshold: int,
-                     cli_tool_settings_dict: dict, verbose_logfile: str, threads: int = 1):
+                     tool_settings: ToolSettings, verbose_logfile: str, override_circlator_min_length: int = None):
     """
     Attempt to stitch the ends of an input circular contig via assembling reads mapped within x bp of the contig ends.
 
@@ -273,11 +302,11 @@ def link_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: str, length_o
                           before the function is run
     :param length_threshold: bp region around the contig ends to subset for the assembly (half of this distance will be
                              targeted from each contig end)
-    :param cli_tool_settings_dict: dictionary containing the following CLI tool settings, as defined in main(), as keys:
-                                   flye_read_mode, flye_read_error, circlator_min_id, circlator_min_length,
-                                   circlator_ref_end, circlator_reassemble_end
+    :param tool_settings: ToolSettings object containing settings for analysis tools used in the end repair workflow.
     :param verbose_logfile: path to a log file where shell script logs will be saved
-    :param threads: parallel processor threads to use for the analysis
+    :param override_circlator_min_length: optionally set a circlator_min_length argument to be used in place of the
+                                          one provided in tool_settings. This can be useful if you know the contig is
+                                          too short for the specified min_length to work for stitching.
     :return: exit status code for Flye
     """
 
@@ -293,13 +322,13 @@ def link_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: str, length_o
     generate_bed_file(contig_record, bed_filepath, length_threshold=length_threshold)
     subset_reads_from_bam(bam_filepath=bam_filepath, bed_filepath=bed_filepath,
                           subset_fastq_filepath=ends_fastq_filepath, log_filepath=verbose_logfile,
-                          append_log=True, threads=threads)
+                          append_log=True, threads=tool_settings.threads)
 
     # Assemble the reads to get (hopefully) a joined contig end
     flye_exit_status = run_flye(fastq_filepath=ends_fastq_filepath, flye_outdir=flye_length_outdir,
-                                flye_read_mode=cli_tool_settings_dict['flye_read_mode'],
-                                flye_read_error=cli_tool_settings_dict['flye_read_error'],
-                                log_filepath=verbose_logfile, append_log=True, threads=threads)
+                                flye_read_mode=tool_settings.flye_read_mode,
+                                flye_read_error=tool_settings.flye_read_error,
+                                log_filepath=verbose_logfile, append_log=True, threads=tool_settings.threads)
 
     if flye_exit_status == 0:
         # Write the original contig sequence to a file
@@ -311,12 +340,14 @@ def link_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: str, length_o
         # Stitch the joined contig end onto the original assembly
         # TODO - sometimes small contigs are already rotated far from original origin. Stitch point is
         #        hard to find. Does circlator report stitch point?
+        circlator_min_length = override_circlator_min_length if override_circlator_min_length \
+            else tool_settings.circlator_min_length
         run_circlator_merge(circular_contig_filepath=circular_contig_filepath,
                             patch_contig_filepath=os.path.join(flye_length_outdir, 'assembly.fasta'),
-                            merge_outdir=merge_dir, circlator_min_id=cli_tool_settings_dict['circlator_min_id'],
-                            circlator_min_length=cli_tool_settings_dict['circlator_min_length'],
-                            circlator_ref_end=cli_tool_settings_dict['circlator_ref_end'],
-                            circlator_reassemble_end=cli_tool_settings_dict['circlator_reassemble_end'],
+                            merge_outdir=merge_dir, circlator_min_id=tool_settings.circlator_min_id,
+                            circlator_min_length=circlator_min_length,
+                            circlator_ref_end=tool_settings.circlator_ref_end,
+                            circlator_reassemble_end=tool_settings.circlator_reassemble_end,
                             log_filepath=verbose_logfile, append_log=True)
     else:
         logger.warning('Flye assembly FAILED')
@@ -325,23 +356,19 @@ def link_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: str, length_o
 
 
 def iterate_linking_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: str, linking_outdir: str,
-                                length_thresholds: list, cli_tool_settings_dict: dict, verbose_logfile: str,
-                                threads: int = 1):
+                                length_thresholds: list, tool_settings: ToolSettings, verbose_logfile: str):
     """
     Iterate link_contig_ends to try to stitch the ends of a circular contig using multiple length thresholds.
 
-    :param contig_record: SeqRecord of the circular contig
+    :param contig_record: SeqRecord of the circular contig.
     :param bam_filepath: path to a BAM file with mapping information of long reads to the contig (it is OK if this file
-                         also contains mappings to other contigs outside the contig of interest)
+                         also contains mappings to other contigs outside the contig of interest).
     :param linking_outdir: output directory for the analysis; will be created by the function, although it can exist
-                           before the function is run
-    :param length_thresholds: list of bp regions around the contig ends to attempt to subset for the assembly
-    :param cli_tool_settings_dict: dictionary containing the following CLI tool settings, as defined in main(), as keys:
-                                   flye_read_mode, flye_read_error, circlator_min_id, circlator_min_length,
-                                   circlator_ref_end, circlator_reassemble_end
-    :param verbose_logfile: path to a logfile where shell script logs will be saved
-    :param threads: parallel processor threads to use for the analysis
-    :return: boolean of whether end linkage was successful (True) or not (False)
+                           before the function is run.
+    :param length_thresholds: list of bp regions around the contig ends to attempt to subset for the assembly.
+    :param tool_settings: ToolSettings object containing settings for analysis tools used in the end repair workflow.
+    :param verbose_logfile: path to a logfile where shell script logs will be saved.
+    :return: boolean of whether end linkage was successful (True) or not (False).
     """
 
     os.makedirs(linking_outdir, exist_ok=True)
@@ -369,22 +396,19 @@ def iterate_linking_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: st
             continue
 
         # Make sure that the circlator_min_length is shorter than the length threshold (otherwise merging is impossible)
-        if cli_tool_settings_dict['circlator_min_length'] > length_threshold:
+        if tool_settings.circlator_min_length > length_threshold:
             revised_min_length = int(length_threshold * 0.9)
-            cli_tool_settings_dict_revised = cli_tool_settings_dict.copy()
-            cli_tool_settings_dict_revised['circlator_min_length'] = revised_min_length
+            override_circlator_min_length = revised_min_length
 
             logger.warning(f'The minimum required length of alignment between the original and reassembled contig '
-                           f'(specified by circlator_min_length; {cli_tool_settings_dict["circlator_min_length"]} bp) '
-                           f'is longer than the length_threshold the original contig will be subset to '
-                           f'({length_threshold} bp). This means that finding a matching merge will be impossible. To '
-                           f'overcome this, the script will shorter the circlator_min_length for this iteration to 90% '
-                           f'of the length threshold, i.e., {revised_min_length} bp.')
-
-            cli_tool_settings_dict_used = cli_tool_settings_dict_revised
+                           f'(specified by circlator_min_length; {tool_settings.circlator_min_length} bp) is longer '
+                           f'than the length_threshold the original contig will be subset to ({length_threshold} bp). '
+                           f'This means that finding a matching merge will be impossible. To overcome this, the script '
+                           f'will shorten the circlator_min_length for this iteration to 90% of the length threshold, '
+                           f'i.e., {revised_min_length} bp.')
 
         else:
-            cli_tool_settings_dict_used = cli_tool_settings_dict
+            override_circlator_min_length = None
 
         # Try to stitch the contig ends
         logger.info(f'Attempting reassembly with a length threshold of {length_threshold} bp')
@@ -392,8 +416,8 @@ def iterate_linking_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: st
 
         flye_exit_status = link_contig_ends(contig_record=contig_record, bam_filepath=bam_filepath,
                                             length_outdir=length_outdir, length_threshold=length_threshold,
-                                            cli_tool_settings_dict=cli_tool_settings_dict_used,
-                                            verbose_logfile=verbose_logfile, threads=threads)
+                                            tool_settings=tool_settings, verbose_logfile=verbose_logfile,
+                                            override_circlator_min_length=override_circlator_min_length)
 
         # Make the output logging directory (this is needed even if Flye fails so the pipeline can keep going)
         log_dir = os.path.join(log_dir_base, f'L{length_threshold}')
@@ -430,19 +454,16 @@ def iterate_linking_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: st
     return linked_ends
 
 
-def stitch_all_contigs(repair_paths: RepairPaths, length_thresholds: list, cli_tool_settings_dict: dict, threads: int):
+def stitch_all_contigs(repair_paths: RepairPaths, length_thresholds: list, tool_settings: ToolSettings):
     """
     Run the iterate_linking_contig_ends function on all contigs in an input FastA file, i.e., attempt to stitch the ends
     of all the contigs (assumed circular) in the file. Writes stitched contigs to end_repaired_contigs_filepath.
 
     :param repair_paths: RepairPaths object containing paths to output files used in the repair process.
-    :param length_thresholds: list of bp regions around the contig ends to attempt to subset for the assembly
-    :param cli_tool_settings_dict: dictionary containing the following CLI tool settings, as defined in main(), as keys:
-                                   flye_read_mode, flye_read_error, circlator_min_id, circlator_min_length,
-                                   circlator_ref_end, circlator_reassemble_end
-    :param threads: parallel processor threads to use for the analysis
+    :param length_thresholds: list of bp regions around the contig ends to attempt to subset for the assembly.
+    :param tool_settings: ToolSettings object containing settings for analysis tools used in the end repair workflow.
     :return: list of the names of any contigs that could not be stitched successfully (list length will be zero if all
-             contigs stitched successfully)
+             contigs stitched successfully).
     """
 
     # Initialize the repaired contigs FastA file (so it will overwrite an old file rather than just append later)
@@ -460,8 +481,8 @@ def stitch_all_contigs(repair_paths: RepairPaths, length_thresholds: list, cli_t
             # This is the temp folder that will be used for this contig during stitching
             linking_outdir = os.path.join(repair_paths.linking_outdir_base, contig_record.name)
             end_linkage_complete = iterate_linking_contig_ends(contig_record, repair_paths.bam_filepath, linking_outdir,
-                                                               length_thresholds, cli_tool_settings_dict,
-                                                               repair_paths.verbose_logfile, threads)
+                                                               length_thresholds, tool_settings,
+                                                               repair_paths.verbose_logfile, tool_settings.threads)
 
             if end_linkage_complete is False:
                 logger.warning(f'Contig {contig_record.name}: FAILED to linked contig ends')
@@ -489,22 +510,18 @@ def stitch_all_contigs(repair_paths: RepairPaths, length_thresholds: list, cli_t
 
 
 def run_end_repair(long_read_filepath: str, assembly_info: AssemblyInfo, output_dir: str, length_thresholds: list,
-                   keep_failed_contigs: bool, cli_tool_settings_dict: dict, threads: int, threads_mem_mb: int):
+                   keep_failed_contigs: bool, tool_settings: ToolSettings):
     """
     Runs the end repair workflow.
 
-    :param long_read_filepath: path to the QC-passing Nanopore reads, FastQ format; gzipped is OK
+    :param long_read_filepath: path to the QC-passing Nanopore reads, FastQ format; gzipped is OK.
     :param assembly_info: AssemblyInfo object with files paths containing info about the input assembly
-    :param output_dir: path to the directory to save output files
+    :param output_dir: path to the directory to save output files.
     :param length_thresholds: list of bp regions around the contig ends to attempt to subset for the assembly
     :param keep_failed_contigs: boolean that defines whether to 1) continue the code even if some contigs cannot be end
                                  repaired (True) vs. to 2) exit with an error code if some contigs cannot be end
-                                 repaired (False)
-    :param cli_tool_settings_dict: dictionary containing the following CLI tool settings, as defined in main(), as keys:
-                                   flye_read_mode, flye_read_error, circlator_min_id, circlator_min_length,
-                                   circlator_ref_end, circlator_reassemble_end
-    :param threads: parallel processor threads to use for the analysis
-    :param threads_mem_mb: memory in MB per thread (to use for samtools); must be an integer
+                                 repaired (False).
+    :param tool_settings: ToolSettings object containing settings for analysis tools used in the end repair workflow.
     """
 
     repair_paths = RepairPaths(output_dir)
@@ -529,10 +546,10 @@ def run_end_repair(long_read_filepath: str, assembly_info: AssemblyInfo, output_
     logger.info('Mapping reads to all contigs')
     map_long_reads(contig_filepath=assembly_info.assembly_fasta_filepath, long_read_filepath=long_read_filepath,
                    output_bam_filepath=repair_paths.bam_filepath, log_filepath=repair_paths.verbose_logfile,
-                   append_log=False, threads=threads, threads_mem_mb=threads_mem_mb)
+                   append_log=False, threads=tool_settings.threads, threads_mem_mb=tool_settings.threads_mem_mb)
 
     failed_contig_names = stitch_all_contigs(repair_paths=repair_paths, length_thresholds=length_thresholds,
-                                             cli_tool_settings_dict=cli_tool_settings_dict, threads=threads)
+                                             tool_settings=tool_settings, threads=threads)
     os.makedirs(repair_paths.circlator_logs, exist_ok=True)
     shutil.move(os.path.join(repair_paths.linking_outdir_base, 'log_summary'), repair_paths.circlator_logs)
 
@@ -609,8 +626,8 @@ def repair_handle_failed_contigs(assembly_info: AssemblyInfo, repair_paths: Repa
     if keep_failed_contigs is False:
         logger.error(f'{len(failed_contig_names)} contigs could not be circularized. A partial output file '
                      f'including successfully circularized contigs (and no linear contigs) is available at '
-                     f'{repair_paths.end_repaired_contigs_filepath} for debugging. Exiting with error status. See temporary '
-                     f'files and verbose logs for more details.')
+                     f'{repair_paths.end_repaired_contigs_filepath} for debugging. Exiting with error status. See '
+                     f'temporary files and verbose logs for more details.')
         sys.exit(1)
     elif keep_failed_contigs is True:
         logger.warning(f'{len(failed_contig_names)} contigs could not be circularized. The original (non-repaired) '

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -587,7 +587,8 @@ def write_repair_info(contig_info, repair_paths):
     repair_info.to_csv(repair_paths.end_repair_status_filepath, sep='\t', index=False)
 
 
-def repair_handle_failed_contigs(assembly_info, repair_paths, failed_contig_names, keep_failed_contigs, output_dir):
+def repair_handle_failed_contigs(assembly_info: AssemblyInfo, repair_paths: RepairPaths, failed_contig_names,
+                                 keep_failed_contigs, output_dir):
     """
     Repair and handle failed contigs in the assembly.
 
@@ -623,7 +624,7 @@ def repair_handle_failed_contigs(assembly_info, repair_paths, failed_contig_name
         raise error
 
 
-def repair_no_circular_input_contigs(assembly, repair_paths):
+def repair_no_circular_input_contigs(assembly: AssemblyInfo, repair_paths: RepairPaths):
     """
     Handle repair when no circular contigs are found.
     """

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -434,6 +434,44 @@ def stitch_all_contigs(circular_contig_tmp_fasta: str, bam_filepath: str, linkin
     return failed_contig_names
 
 
+class RepairPaths:
+    """
+    A class containing file paths that are used during the assembly repair process.
+    """
+
+    def __init__(self, output_dir):
+        self.linking_outdir_base = os.path.join(output_dir, 'contigs')
+        self.end_repaired_contigs_filepath = os.path.join(output_dir, 'repaired.fasta')
+        self.end_repair_status_filepath = os.path.join(output_dir, 'repaired_info.tsv')
+        self.verbose_logfile = os.path.join(output_dir, 'verbose.log')
+        self.bam_filepath = os.path.join(output_dir, 'long_read.bam')
+        self.circlator_logs = os.path.join(output_dir, 'circlator_logs')
+        self.contigs = os.path.join(output_dir, 'contigs')
+        self.circular_contig_tmp_fasta = os.path.join(self.linking_outdir_base, 'circular_input.fasta')
+
+
+class AssemblyInfo:
+    """
+    A class representing files paths containing info about the input assembly.
+    """
+
+    def __init__(self, assembly_fasta_filepath, assembly_info_filepath, assembly_info_type):
+        self.assembly_fasta_filepath = assembly_fasta_filepath
+        self.assembly_info_filepath = assembly_info_filepath
+        self.assembly_info_type = assembly_info_type
+
+
+class ContigInfo:
+    """
+    A class representing file paths containing info about the contigs of an assembly.
+    """
+    def __init__(self, circular_contig_names, failed_contig_names, linear_contig_names):
+        self.circular_contig_names = circular_contig_names
+        self.repaired_contig_names = list(set(circular_contig_names).difference(set(failed_contig_names)))
+        self.failed_contig_names = failed_contig_names
+        self.linear_contig_names = linear_contig_names
+
+
 def run_end_repair(long_read_filepath: str, assembly_fasta_filepath: str, assembly_info_filepath: str,
                    assembly_info_type: str, output_dir: str, length_thresholds: list, keep_failed_contigs: bool,
                    cli_tool_settings_dict: dict, threads: int, threads_mem_mb: int):

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -107,7 +107,7 @@ class RepairToolSettings:
 
 class AssemblyInfo:
     """
-    A class representing files paths containing info about the input assembly.
+    A class representing file paths containing info about the input assembly.
     """
 
     def __init__(self, assembly_fasta_filepath: str, assembly_info_filepath: str, assembly_info_type: str):
@@ -126,7 +126,7 @@ class AssemblyInfo:
 
 class RepairPaths:
     """
-    A class containing file paths that are used during the assembly repair process.
+    A class representing file paths that are used during the assembly repair process.
     """
 
     def __init__(self, output_dir: str):
@@ -157,7 +157,7 @@ class RepairPaths:
 
 class StitchDirectories:
     """
-    A class containing directory paths that are used during a single iteration of the assembly and stitch process.
+    A class representing directory paths that are used during a single iteration of the assembly and stitch process.
     """
 
     def __init__(self, linking_outdir: str, length_threshold: int = None, make_dirs: bool = False):

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -79,7 +79,7 @@ class RepairToolSettings:
     """
 
     def __init__(self, flye_read_mode: str, flye_read_error: float, circlator_min_id: float, circlator_min_length: int,
-                 circlator_ref_end: int, circlator_reassemble_end: int, threads: int, threads_mem: float):
+                 circlator_ref_end: int, circlator_reassemble_end: int, threads: int = 1, threads_mem: float = 1.0):
         """
         Instantiate a RepairToolSettings object.
 

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -177,7 +177,7 @@ class StitchDirectories:
             raise error
 
         self.length_threshold = length_threshold
-        self.length_outdir = os.path.join(self.linking_outdir, 'tmp', f'L{length_threshold}')
+        self.length_outdir = os.path.join(self.linking_outdir, f'L{length_threshold}')
         self.log_dir = os.path.join(self.log_dir_base, f'L{length_threshold}')
 
     def make_dirs(self):

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -158,27 +158,50 @@ class StitchDirectories:
         """
         self.linking_outdir = linking_outdir
         self.log_dir_base = os.path.join(linking_outdir, 'logs')
-        self.length_threshold = length_threshold
+        self._current_length_threshold = length_threshold
 
-        if length_threshold:
-            self.length_outdir = os.path.join(linking_outdir, f'L{length_threshold}')
-            self.log_dir = os.path.join(self.log_dir_base, f'L{length_threshold}')
-        else:
-            self.length_outdir = None
-            self.log_dir = None
-
-    def set_length_threshold(self, length_threshold: int):
+    @property
+    def length_threshold(self):
         """
-        Set a new length threshold. Associated directory names are also updated.
+        A property representing the length threshold.
+        """
+        return self._current_length_threshold
+
+    @length_threshold.setter
+    def length_threshold(self, length_threshold: int):
+        """
+        Set a new length threshold.
         """
         if length_threshold < 0:
             error = ValueError(f'Length threshold must be an integer >= 0; you provided {length_threshold}.')
             logger.error(error)
             raise error
 
-        self.length_threshold = length_threshold
-        self.length_outdir = os.path.join(self.linking_outdir, f'L{length_threshold}')
-        self.log_dir = os.path.join(self.log_dir_base, f'L{length_threshold}')
+        self._current_length_threshold = length_threshold
+
+    @property
+    def length_outdir(self):
+        """
+        A property representing a length directory path.
+        """
+        if self.length_threshold:
+            length_outdir = os.path.join(self.linking_outdir, f'L{self.length_threshold}')
+        else:
+            length_outdir = None
+
+        return length_outdir
+
+    @property
+    def log_dir(self):
+        """
+        A property representing a log directory path.
+        """
+        if self.length_threshold:
+            log_dir = os.path.join(self.log_dir_base, f'L{self.length_threshold}')
+        else:
+            log_dir = None
+
+        return log_dir
 
     def make_dirs(self):
         """
@@ -195,6 +218,7 @@ class ContigInfo:
     """
     A class containing contig names from an assembly, separated into lists based on their repair outcomes.
     """
+
     def __init__(self, circular_contig_names: list, failed_contig_names: list, linear_contig_names: list):
         """
         Instantiate a ContigInfo object.
@@ -399,7 +423,7 @@ def iterate_linking_contig_ends(contig_record: SeqIO.SeqRecord, bam_filepath: st
             # add 1 to the total number of assembly attempts.
 
         logger.info(f'Attempting reassembly with a length threshold of {length_threshold} bp')
-        stitch_dirs.set_length_threshold(length_threshold)
+        stitch_dirs.length_threshold = length_threshold
         stitch_dirs.make_dirs()
         length_outdir = stitch_dirs.length_outdir
         log_dir = stitch_dirs.log_dir

--- a/rotary_utils/repair.py
+++ b/rotary_utils/repair.py
@@ -170,10 +170,11 @@ class StitchDirectories:
         """
         Set a new length threshold.
         """
-        if length_threshold < 0:
-            error = ValueError(f'Length threshold must be an integer >= 0; you provided {length_threshold}.')
-            logger.error(error)
-            raise error
+        if length_threshold:
+            if length_threshold < 0:
+                error = ValueError(f'Length threshold must be an integer >= 0; you provided {length_threshold}.')
+                logger.error(error)
+                raise error
 
         self._current_length_threshold = length_threshold
 

--- a/rotary_utils/rotate.py
+++ b/rotary_utils/rotate.py
@@ -58,29 +58,29 @@ def main(args):
 
     # Perform the rotate operation based on which of the rotate arguments was specified by the user
     if args.midpoint is True:
-        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='fraction',
-                                     rotate_value_single=0.5, sequence_names=sequence_names,
-                                     strip_descriptions=args.strip_descriptions)
+        report = rotate_sequences(args.input_fasta, args.output_fasta, rotate_type='fraction',
+                                  rotate_value_single=0.5, sequence_names=sequence_names,
+                                  strip_descriptions=args.strip_descriptions)
     elif args.rotate_position is not None:
-        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='position',
-                                     rotate_value_single=args.rotate_position, sequence_names=sequence_names,
-                                     strip_descriptions=args.strip_descriptions)
+        report = rotate_sequences(args.input_fasta, args.output_fasta, rotate_type='position',
+                                  rotate_value_single=args.rotate_position, sequence_names=sequence_names,
+                                  strip_descriptions=args.strip_descriptions)
     elif args.rotate_fraction is not None:
-        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='fraction',
-                                     rotate_value_single=args.rotate_fraction, sequence_names=sequence_names,
-                                     strip_descriptions=args.strip_descriptions)
+        report = rotate_sequences(args.input_fasta, args.output_fasta, rotate_type='fraction',
+                                  rotate_value_single=args.rotate_fraction, sequence_names=sequence_names,
+                                  strip_descriptions=args.strip_descriptions)
     elif args.rotate_position_table is not None:
         rotate_values_dict = parse_rotate_value_table(args.rotate_position_table, rotate_type='position')
 
-        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='position',
-                                     rotate_values=rotate_values_dict, sequence_names=sequence_names,
-                                     strip_descriptions=args.strip_descriptions)
+        report = rotate_sequences(args.input_fasta, args.output_fasta, rotate_type='position',
+                                  rotate_values=rotate_values_dict, sequence_names=sequence_names,
+                                  strip_descriptions=args.strip_descriptions)
     elif args.rotate_fraction_table is not None:
         rotate_values_dict = parse_rotate_value_table(args.rotate_fraction_table, rotate_type='fraction')
 
-        report = rotate_sequences_wf(args.input_fasta, args.output_fasta, rotate_type='fraction',
-                                     rotate_values=rotate_values_dict, sequence_names=sequence_names,
-                                     strip_descriptions=args.strip_descriptions)
+        report = rotate_sequences(args.input_fasta, args.output_fasta, rotate_type='fraction',
+                                  rotate_values=rotate_values_dict, sequence_names=sequence_names,
+                                  strip_descriptions=args.strip_descriptions)
 
     else:
         raise RuntimeError('Could not find any rotate commands to execute.')
@@ -260,9 +260,9 @@ def rotate_sequence_to_fraction(sequence_record: SeqIO.SeqRecord, rotate_fractio
     return sequence_record
 
 
-def rotate_sequences_wf(fasta_filepath: str, output_filepath: str, rotate_type: str, rotate_values: dict = None,
-                        rotate_value_single: float = None, sequence_names: list = None, max_sequences_in_file: int = 0,
-                        append: bool = False, strip_descriptions: bool = True):
+def rotate_sequences(fasta_filepath: str, output_filepath: str, rotate_type: str, rotate_values: dict = None,
+                     rotate_value_single: float = None, sequence_names: list = None, max_sequences_in_file: int = 0,
+                     append: bool = False, strip_descriptions: bool = True):
     """
     Rotates all (circular) sequences in an input FastA file to specified positions or fractions.
 

--- a/rotary_utils/utils.py
+++ b/rotary_utils/utils.py
@@ -8,8 +8,6 @@ import sys
 
 from Bio import SeqIO
 
-from rotary_utils.external import logger
-
 logger = logging.getLogger(__name__)
 
 

--- a/rotary_utils/utils.py
+++ b/rotary_utils/utils.py
@@ -2,15 +2,13 @@
 # utils.py
 # Utility function within rotary-utils
 # Copyright Jackson M. Tsuji and Lee H. Bergstrand 2024
-
+import logging
 import os
 import sys
-import logging
-import shlex
-import shutil
-import subprocess
 
 from Bio import SeqIO
+
+from rotary_utils.external import logger
 
 logger = logging.getLogger(__name__)
 
@@ -59,82 +57,6 @@ def set_up_output_directory(output_directory_filepath: str, overwrite: bool = Fa
     os.makedirs(output_directory_filepath, exist_ok=True)
 
 
-def get_dependency_version(dependency_name: str, log: bool = False):
-    """
-    Tries to get the version of a dependency based on the name of the dependency.
-
-    :param dependency_name: name of the dependency
-    :param log: is True, print a log of the shell commands used
-    :return: version of the dependency. 'unknown' if no version can be parsed
-    """
-
-    if dependency_name == 'flye':
-        stdout = run_pipeline_subcommand(['flye', '--version'], stdout=subprocess.PIPE, text=True,
-                                         log=log).stdout
-        dependency_version = stdout.splitlines()[0]
-
-    elif dependency_name == 'minimap2':
-        stdout = run_pipeline_subcommand(['minimap2', '--version'], stdout=subprocess.PIPE, text=True,
-                                         log=log).stdout
-        dependency_version = stdout.splitlines()[0]
-
-    elif dependency_name == 'samtools':
-        stdout = run_pipeline_subcommand(['samtools', 'version'], stdout=subprocess.PIPE, text=True,
-                                         log=log).stdout
-        dependency_version = stdout.splitlines()[0].split(' ')[1]
-
-    elif dependency_name == 'circlator':
-        stdout = run_pipeline_subcommand(['circlator', 'version'], stdout=subprocess.PIPE, text=True,
-                                         log=log).stdout
-        dependency_version = stdout.splitlines()[0]
-
-    else:
-        dependency_version = 'unknown'
-
-    return dependency_version
-
-
-def check_dependency(dependency_name: str):
-    """
-    Checks if a required shell dependency is present and tries to get its version.
-
-    :param dependency_name: name of the dependency
-    :return: tuple of the path to the dependency and dependency version
-    """
-
-    dependency_path = shutil.which(dependency_name)
-    if dependency_path is None:
-        error = FileNotFoundError(f'Dependency not found: {dependency_name}')
-        logger.error(error)
-        raise error
-
-    dependency_version = get_dependency_version(dependency_name)
-
-    output_tuple = (dependency_path, dependency_version)
-    return output_tuple
-
-
-def check_dependencies(dependency_names: list):
-    """
-    For each provided dependency name, checks if the dependency exists and gets the path and version.
-
-    :param dependency_names: a list of names of dependencies to check
-    :return: dictionary with dependency names as key and a tuple of dependency paths and versions as values
-    """
-
-    path_and_version_tuples = []
-    for dependency_name in dependency_names:
-        path_and_version_tuple = check_dependency(dependency_name)
-        path_and_version_tuples.append(path_and_version_tuple)
-
-        dependency_path, dependency_version = path_and_version_tuple
-        logger.debug(f'{dependency_name}: version {dependency_version}: {dependency_path}')
-
-    dependency_dict = dict(zip(dependency_names, path_and_version_tuples))
-
-    return dependency_dict
-
-
 def set_write_mode(append_log: bool):
     """
     Converts the boolean append_log to 'w' or 'a' write modes.
@@ -154,28 +76,6 @@ def set_write_mode(append_log: bool):
         raise error
 
     return write_mode
-
-
-def run_pipeline_subcommand(command_args, stdin=None, stdout=None, stderr=None, check=True, text=None, log=True):
-    """
-    Wrapper function for running subcommands.
-
-    :param command_args: The command line arguments of the subcommand (e.g., ['samtools', '-h'])
-    :param stdin: A subprocess.PIPE or None if stdin is not to be used.
-    :param stdout: Where to send stdout or None if stdout is not to be used.
-    :param stderr: Where to send stderr or None if stderr is not to be used.
-    :param check: Cause a runtime error if the subcommand fails.
-    :param text: If True, open outputs in text mode (rather than binary)
-    :param log: If True, write the shell command to logger in debug mode
-    :return: The output of the subcommand.
-    """
-
-    if log is True:
-        logger.debug(shlex.join(command_args))
-    if stdin:
-        stdin = stdin.stdout
-
-    return subprocess.run(command_args, check=check, input=stdin, stdout=stdout, stderr=stderr, text=text)
 
 
 def load_fasta_sequences(fasta_filepath: str):


### PR DESCRIPTION
@jmtsuji Okay, so I have started a refactoring of the rotary-utils code. I am presenting this as a guide for you. Potential changes to repair.py and the rest of the code have been made to act as a starting point and to introduce some concepts.

### Changes:

1. I moved all the code that calls external programs to a single file called `external.py`. **This forces all the code that involves subcommands to be in one place.** If we choose to use a different CLI program library to call the subcommands down the road, then there will be only one place to look.
2. Refactored `run_end_repair` function. **It's generally a good rule of thumb that a Python function should fit on a single page. It should be broken down into a series of child functions if it doesn't fit on one page.** I have done this. Though they might not make the most sense to you. Feel free to refactor them in different ways.
3. I created a series of data classes, `RepairPaths`, `AssemblyInfo`, and `ContigInfo`, that represent the many variables contained within `run_end_repair`. These objects allow easier refactoring, allowing you to pass bundles of info to functions instead of passing many variables. This is the core of [object-oriented programming (OOP)](https://en.wikipedia.org/wiki/Object-oriented_programming). Some of these objects could be generated outside of the `run_end_repair` and perhaps passed to it and other functions such as `stitch_all_contigs`. I also think that  `AssemblyInfo` and `ContigInfo` could be merged in some ways as contigs are part of an assembly.

To do this refactoring, I made extensive use of Pycharm's automated refactoring tools: https://www.jetbrains.com/help/pycharm/refactoring-source-code.html