### PR TITLE
Update install

### DIFF
--- a/.github/workflows/.condarc
+++ b/.github/workflows/.condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
-      - name: create conda env
+      - name: set up conda
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
@@ -21,6 +21,7 @@ jobs:
           condarc-file: .github/workflows/.condarc
           channel-priority: strict
           auto-activate-base: true
+      - name: create conda env
         shell: bash -el {0}
         run: conda env create --file=environment.yml 
              conda activate spokewrench

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           auto-activate-base: true
       - name: create conda env
         shell: bash -el {0}
-        run: conda env create --file=environment.yml 
+        run: conda env create --file=environment.yml && 
              conda activate spokewrench
       - name: check conda channels
         shell: bash -el {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           channels: conda-forge,bioconda
           show-channel-urls: true
           architecture: x64
+          condarc-file: .github/workflows/.condarc
           environment-file: environment.yml
           channel-priority: strict
           activate-environment: spokewrench

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,12 @@ jobs:
           channel-priority: strict
           activate-environment: spokewrench
           auto-activate-base: false
+      - name: check conda channels
+        shell: bash -el {0}
+        run: conda config --show channels
       - name: install spokewrench
         shell: bash -el {0}
         run: pip install --editable .
-      - name: test install of spokewrench rotate
+      - name: test install of spokewrench
         shell: bash -el {0}
         run: spokewrench -h

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,10 @@ jobs:
           auto-activate-base: true
       - name: create conda env
         shell: bash -el {0}
-        run: conda env create --file=environment.yml && 
-             conda activate spokewrench
+        run: conda env create --file=environment.yml
+      - name: activate conda env
+        shell: bash -el {0}
+        run: conda activate spokewrench
       - name: check conda channels
         shell: bash -el {0}
         run: conda config --show channels

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,24 +11,26 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
-      - name: create conda env
+      - name: set up conda
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           auto-update-conda: true
           python-version: 3.9
-          channels: conda-forge,bioconda
           show-channel-urls: true
           architecture: x64
           condarc-file: .github/workflows/.condarc
-          environment-file: environment.yml
           channel-priority: strict
-          activate-environment: spokewrench
           auto-activate-base: false
       - name: check conda channels
         shell: bash -el {0}
         run: conda config --show channels
+      - name: create conda env
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          environment-file: environment.yml
+          activate-environment: spokewrench
       - name: install spokewrench
         shell: bash -el {0}
         run: pip install --editable .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,15 @@ jobs:
       - name: create conda env
         uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
           auto-update-conda: true
           python-version: 3.9
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda
+          show-channel-urls: true
           architecture: x64
           environment-file: environment.yml
+          channel-priority: strict
           activate-environment: spokewrench
           auto-activate-base: false
       - name: install spokewrench

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,8 @@ jobs:
         shell: bash -el {0}
         run: conda config --show channels
       - name: create conda env
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          environment-file: environment.yml
-          activate-environment: spokewrench
+        shell: bash -el {0}
+        run: conda env create --file=environment.yml && conda activate spokewrench
       - name: install spokewrench
         shell: bash -el {0}
         run: pip install --editable .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,24 +11,25 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
-      - name: set up conda
+      - name: create conda env
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
           auto-update-conda: true
           python-version: 3.9
           show-channel-urls: true
           architecture: x64
           condarc-file: .github/workflows/.condarc
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate-base: true
+        shell: bash -el {0}
+        run: conda env create --file=environment.yml 
+             conda activate spokewrench
       - name: check conda channels
         shell: bash -el {0}
         run: conda config --show channels
-      - name: create conda env
+      - name: check conda env
         shell: bash -el {0}
-        run: conda env create --file=environment.yml && conda activate spokewrench
+        run: conda env list
       - name: install spokewrench
         shell: bash -el {0}
         run: pip install --editable .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,28 +11,23 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
-      - name: set up conda
+      - name: create conda env
         uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
           auto-update-conda: true
           python-version: 3.9
+          channels: conda-forge,bioconda,nodefaults
           show-channel-urls: true
           architecture: x64
-          condarc-file: .github/workflows/.condarc
+          environment-file: environment.yml
           channel-priority: strict
-          auto-activate-base: true
-      - name: create conda env
-        shell: bash -el {0}
-        run: conda env create --file=environment.yml
-      - name: activate conda env
-        shell: bash -el {0}
-        run: conda activate spokewrench
+          activate-environment: spokewrench
+          auto-activate-base: false
       - name: check conda channels
         shell: bash -el {0}
         run: conda config --show channels
-      - name: check conda env
-        shell: bash -el {0}
-        run: conda env list
       - name: install spokewrench
         shell: bash -el {0}
         run: pip install --editable .

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: spokewrench
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.9.*
   - pandas=1.4.*


### PR DESCRIPTION
Like mentioned in [BackBLAST PR 65](https://github.com/LeeBergstrand/BackBLAST_Reciprocal_BLAST/pull/65), update the install of spokewrench so that curated conda channels are not required.