### PR TITLE
Update spokewrench installation

### DIFF
--- a/.github/workflows/.condarc
+++ b/.github/workflows/.condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           architecture: x64
           environment-file: environment.yml
           channel-priority: strict
+          show-channel-urls: true
           activate-environment: spokewrench
           auto-activate-base: false
       - name: install spokewrench

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
       - name: create conda env
         uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
           auto-update-conda: true
           python-version: 3.9
           channels: conda-forge,bioconda

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,10 @@ jobs:
         with:
           auto-update-conda: true
           python-version: 3.9
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda
           architecture: x64
           environment-file: environment.yml
+          channel-priority: strict
           activate-environment: spokewrench
           auto-activate-base: false
       - name: install spokewrench

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,11 @@ jobs:
         with:
           miniforge-variant: Miniforge3
           miniforge-version: latest
-          auto-update-conda: true
           python-version: 3.9
           channels: conda-forge,bioconda
           architecture: x64
+          auto-update-conda: ""
+          condarc-file: .github/workflows/.condarc
           environment-file: environment.yml
           channel-priority: strict
           show-channel-urls: true

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: spokewrench
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.9.*
   - pandas=1.4.*


### PR DESCRIPTION
Like mentioned in [BackBLAST PR 65](https://github.com/LeeBergstrand/BackBLAST_Reciprocal_BLAST/pull/65), update the install of spokewrench so that curated conda channels are not required. I updated both the spokewrench environment file and the GitHub Actions workflow to remove the "defaults" channel. End-to-end tests pass successfully on Mac when spokewrench is installed without the "defaults" channel. Automated installation tests (via GitHub Actions) are passing on both Mac and Ubuntu. @LeeBergstrand Would you mind giving your review? Thanks!
